### PR TITLE
Support Zig 0.16 alongisde 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
 zig-cache/
 zig-out/
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -67,17 +67,18 @@ pub fn build(b: *std.Build) void {
         const lint_step = b.step("lint", "Run zsort check-imports on the repo");
         lint_step.dependOn(&check_imports.step);
     } else {
-        const zwanzig = b.dependency("zwanzig", .{
+        if (b.lazyDependency("zwanzig", .{
             .target = b.graph.host,
             .optimize = .ReleaseFast,
-        });
-        const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
-        run_zwanzig.setCwd(b.path("."));
+        })) |zwanzig| {
+            const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
+            run_zwanzig.setCwd(b.path("."));
 
-        run_zwanzig.addArgs(&.{ "src", "build.zig" });
-        const lint_step = b.step("lint", "Run Zwanzig on the whole repo");
-        lint_step.dependOn(&run_zwanzig.step);
-        lint_step.dependOn(&check_imports.step);
+            run_zwanzig.addArgs(&.{ "src", "build.zig" });
+            const lint_step = b.step("lint", "Run Zwanzig on the whole repo");
+            lint_step.dependOn(&run_zwanzig.step);
+            lint_step.dependOn(&check_imports.step);
+        }
     }
 
     // `zig build check` is not built-in on 0.15.2; define a compile-only step

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -59,17 +60,25 @@ pub fn build(b: *std.Build) void {
     const fix_imports_step = b.step("fix-imports", "Fix Zig import ordering in this repo");
     fix_imports_step.dependOn(&run_fix_imports.step);
 
-    const zwanzig = b.dependency("zwanzig", .{
-        .target = b.graph.host,
-        .optimize = .ReleaseFast,
-    });
-    const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
-    run_zwanzig.setCwd(b.path("."));
+    // Zwanzig's analyzer and build.zig are not Zig 0.16 compatible
+    // (std.fs was removed). Gate the dependency to <0.16; on 0.16 the lint
+    // step only runs the dogfood import check.
+    if (comptime builtin.zig_version.major == 0 and builtin.zig_version.minor >= 16) {
+        const lint_step = b.step("lint", "Run zsort check-imports on the repo");
+        lint_step.dependOn(&check_imports.step);
+    } else {
+        const zwanzig = b.dependency("zwanzig", .{
+            .target = b.graph.host,
+            .optimize = .ReleaseFast,
+        });
+        const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
+        run_zwanzig.setCwd(b.path("."));
 
-    run_zwanzig.addArgs(&.{ "src", "build.zig" });
-    const lint_step = b.step("lint", "Run Zwanzig on the whole repo");
-    lint_step.dependOn(&run_zwanzig.step);
-    lint_step.dependOn(&check_imports.step);
+        run_zwanzig.addArgs(&.{ "src", "build.zig" });
+        const lint_step = b.step("lint", "Run Zwanzig on the whole repo");
+        lint_step.dependOn(&run_zwanzig.step);
+        lint_step.dependOn(&check_imports.step);
+    }
 
     // `zig build check` is not built-in on 0.15.2; define a compile-only step
     // covering the exe, the library module, and the tests.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,6 +6,7 @@
         .zwanzig = .{
             .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.14.0.tar.gz",
             .hash = "zwanzig-0.14.0-oiXZljvxGACKRbJD3WEVSKM_gbCm6GUsrz2_TbFP7xfe",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -150,6 +150,7 @@ pub fn runParallel(io: Io, allocator: std.mem.Allocator, comptime Job: type, com
         for (jobs) |*job| g.async(io, function, .{ job, io });
         try g.await(io);
     } else {
+        // SAFETY: `pool` is only written by init() below, never read before it.
         var pool: std.Thread.Pool = undefined;
         try std.Thread.Pool.init(&pool, .{ .allocator = allocator, .n_jobs = null });
         defer pool.deinit();

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,151 @@
+//! Cross-version std shims for Zig 0.15 (std.fs Dir API) vs 0.16 (std.Io).
+//! Every branch is comptime-known, so the dead version's code is never
+//! semantically analyzed and both versions compile from this one file.
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub const is_v016 = builtin.zig_version.major == 0 and builtin.zig_version.minor >= 16;
+
+pub const Io = if (is_v016) std.Io else void;
+pub const Dir = if (is_v016) std.Io.Dir else std.fs.Dir;
+pub const Entry = if (is_v016) std.Io.Dir.Entry else std.fs.Dir.Entry;
+pub const Iterator = if (is_v016) std.Io.Dir.Iterator else std.fs.Dir.Iterator;
+pub const OpenOptions = if (is_v016) std.Io.Dir.OpenOptions else std.fs.Dir.OpenOptions;
+pub const Stat = if (is_v016) std.Io.File.Stat else std.fs.File.Stat;
+
+pub fn cwd() Dir {
+    if (is_v016) return std.Io.Dir.cwd();
+    return std.fs.cwd();
+}
+
+pub fn readFileAlloc(io: Io, dir: Dir, path: []const u8, allocator: std.mem.Allocator, max: usize) ![]u8 {
+    if (is_v016) return std.Io.Dir.readFileAlloc(dir, io, path, allocator, .limited(max));
+    return dir.readFileAlloc(allocator, path, max);
+}
+
+pub fn statFile(io: Io, dir: Dir, path: []const u8) !Stat {
+    if (is_v016) return std.Io.Dir.statFile(dir, io, path, .{});
+    return dir.statFile(path);
+}
+
+pub fn openDir(io: Io, dir: Dir, path: []const u8, options: OpenOptions) !Dir {
+    if (is_v016) return std.Io.Dir.openDir(dir, io, path, options);
+    return dir.openDir(path, options);
+}
+
+pub fn iterate(dir: Dir) Iterator {
+    if (is_v016) return std.Io.Dir.iterate(dir);
+    return dir.iterate();
+}
+
+pub fn next(io: Io, it: *Iterator) !?Entry {
+    if (is_v016) return it.next(io);
+    return it.next();
+}
+
+pub fn close(io: Io, dir: *Dir) void {
+    if (is_v016) {
+        dir.close(io);
+    } else {
+        dir.close();
+    }
+}
+
+pub fn atomicWrite(io: Io, dir: Dir, path: []const u8, contents: []const u8) !void {
+    if (is_v016) {
+        var af = try std.Io.Dir.createFileAtomic(dir, io, path, .{ .replace = true });
+        defer af.deinit(io);
+        try std.Io.File.writeStreamingAll(af.file, io, contents);
+        try af.replace(io);
+        return;
+    }
+    var buf: [4096]u8 = undefined;
+    var af = try dir.atomicFile(path, .{ .write_buffer = &buf });
+    defer af.deinit();
+    try af.file_writer.interface.writeAll(contents);
+    try af.finish();
+}
+
+pub fn makePath(io: Io, dir: Dir, path: []const u8) !void {
+    if (is_v016) return std.Io.Dir.createDirPath(dir, io, path);
+    return dir.makePath(path);
+}
+
+pub fn writeFile(io: Io, dir: Dir, sub_path: []const u8, data: []const u8) !void {
+    if (is_v016) return std.Io.Dir.writeFile(dir, io, .{ .sub_path = sub_path, .data = data });
+    return dir.writeFile(.{ .sub_path = sub_path, .data = data });
+}
+
+/// Writer over an `ArrayListUnmanaged(u8)`. 0.15 writes into the list in
+/// place; 0.16's `Io.Writer.Allocating` moves the list in and back out.
+pub const ListWriter = if (is_v016) struct {
+    inner: std.Io.Writer.Allocating,
+
+    pub fn init(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8)) ListWriter {
+        return .{ .inner = .fromArrayList(allocator, list) };
+    }
+
+    pub fn print(self: *ListWriter, comptime fmt: []const u8, args: anytype) !void {
+        try self.inner.writer.print(fmt, args);
+    }
+
+    pub fn writeByte(self: *ListWriter, byte: u8) !void {
+        try self.inner.writer.writeByte(byte);
+    }
+
+    pub fn toArrayList(self: *ListWriter) std.ArrayListUnmanaged(u8) {
+        return self.inner.toArrayList();
+    }
+} else struct {
+    list: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8)) ListWriter {
+        return .{ .list = list, .allocator = allocator };
+    }
+
+    pub fn print(self: *ListWriter, comptime fmt: []const u8, args: anytype) !void {
+        var w = self.list.writer(self.allocator);
+        try w.print(fmt, args);
+    }
+
+    pub fn writeByte(self: *ListWriter, byte: u8) !void {
+        var w = self.list.writer(self.allocator);
+        try w.writeByte(byte);
+    }
+
+    pub fn toArrayList(self: *ListWriter) std.ArrayListUnmanaged(u8) {
+        return self.list.*;
+    }
+};
+
+pub const Timer = if (is_v016) struct {
+    io: std.Io,
+    started: std.Io.Timestamp,
+
+    pub fn start(io: std.Io) !Timer {
+        return .{ .io = io, .started = std.Io.Timestamp.now(io, .awake) };
+    }
+
+    pub fn read(self: *Timer) u64 {
+        const end = std.Io.Timestamp.now(self.io, .awake);
+        return @intCast(self.started.durationTo(end).toNanoseconds());
+    }
+} else struct {
+    inner: std.time.Timer,
+
+    pub fn start(_: void) !Timer {
+        return .{ .inner = try std.time.Timer.start() };
+    }
+
+    pub fn read(self: *Timer) u64 {
+        return self.inner.read();
+    }
+};
+
+/// The `Io` instance tests should use (0.16 only; `void` on 0.15).
+/// Only call this from test code: `std.testing.io` errors outside a test build.
+pub fn testIo() Io {
+    if (is_v016) return std.testing.io;
+    return {};
+}

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -76,49 +76,6 @@ pub fn writeFile(io: Io, dir: Dir, sub_path: []const u8, data: []const u8) !void
     return dir.writeFile(.{ .sub_path = sub_path, .data = data });
 }
 
-/// Writer over an `ArrayListUnmanaged(u8)`. 0.15 writes into the list in
-/// place; 0.16's `Io.Writer.Allocating` moves the list in and back out.
-pub const ListWriter = if (is_v016) struct {
-    inner: std.Io.Writer.Allocating,
-
-    pub fn init(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8)) ListWriter {
-        return .{ .inner = .fromArrayList(allocator, list) };
-    }
-
-    pub fn print(self: *ListWriter, comptime fmt: []const u8, args: anytype) !void {
-        try self.inner.writer.print(fmt, args);
-    }
-
-    pub fn writeByte(self: *ListWriter, byte: u8) !void {
-        try self.inner.writer.writeByte(byte);
-    }
-
-    pub fn toArrayList(self: *ListWriter) std.ArrayListUnmanaged(u8) {
-        return self.inner.toArrayList();
-    }
-} else struct {
-    list: *std.ArrayListUnmanaged(u8),
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8)) ListWriter {
-        return .{ .list = list, .allocator = allocator };
-    }
-
-    pub fn print(self: *ListWriter, comptime fmt: []const u8, args: anytype) !void {
-        var w = self.list.writer(self.allocator);
-        try w.print(fmt, args);
-    }
-
-    pub fn writeByte(self: *ListWriter, byte: u8) !void {
-        var w = self.list.writer(self.allocator);
-        try w.writeByte(byte);
-    }
-
-    pub fn toArrayList(self: *ListWriter) std.ArrayListUnmanaged(u8) {
-        return self.list.*;
-    }
-};
-
 pub const Timer = if (is_v016) struct {
     io: std.Io,
     started: std.Io.Timestamp,
@@ -148,4 +105,92 @@ pub const Timer = if (is_v016) struct {
 pub fn testIo() Io {
     if (is_v016) return std.testing.io;
     return {};
+}
+
+pub fn printStdout(io: Io, comptime fmt: []const u8, args: anytype) void {
+    if (is_v016) {
+        var obuf: [4096]u8 = undefined;
+        var w = std.Io.File.stdout().writer(io, &obuf);
+        w.interface.print(fmt, args) catch return;
+        w.flush() catch return;
+    } else {
+        var obuf: [4096]u8 = undefined;
+        var w = std.fs.File.stdout().writer(&obuf);
+        w.interface.print(fmt, args) catch return;
+        w.interface.flush() catch return;
+    }
+}
+
+pub fn writeStdout(io: Io, bytes: []const u8) void {
+    if (is_v016) {
+        var obuf: [4096]u8 = undefined;
+        var w = std.Io.File.stdout().writer(io, &obuf);
+        w.interface.writeAll(bytes) catch return;
+        w.flush() catch return;
+    } else {
+        var obuf: [4096]u8 = undefined;
+        var w = std.fs.File.stdout().writer(&obuf);
+        w.interface.writeAll(bytes) catch return;
+        w.interface.flush() catch return;
+    }
+}
+
+pub fn isTty(io: Io) bool {
+    if (is_v016) {
+        return std.Io.File.isTty(std.Io.File.stdout(), io) catch return false;
+    }
+    return std.posix.isatty(std.fs.File.stdout().handle);
+}
+
+/// Spawn `function` over `jobs` and wait for all of them. `function` must be
+/// `fn (*const Job, Io) void`; on 0.15 the `Io` argument is `void`.
+pub fn runParallel(io: Io, allocator: std.mem.Allocator, comptime Job: type, comptime function: anytype, jobs: []Job) !void {
+    if (is_v016) {
+        var g: std.Io.Group = .init;
+        for (jobs) |*job| g.async(io, function, .{ job, io });
+        try g.await(io);
+    } else {
+        var pool: std.Thread.Pool = undefined;
+        try std.Thread.Pool.init(&pool, .{ .allocator = allocator, .n_jobs = null });
+        defer pool.deinit();
+        var wg: std.Thread.WaitGroup = .{};
+        for (jobs) |*job| pool.spawnWg(&wg, function, .{ job, {} });
+        pool.waitAndWork(&wg);
+    }
+}
+
+/// Returns a type whose `main` has the correct signature for the active Zig
+/// version; it wires up the arena, command line args, and `Io` and then
+/// calls `run_main(allocator, args, io)`.
+pub fn entry(comptime run_main: anytype) type {
+    const run = run_main;
+    return struct {
+        fn mainV15() !void {
+            var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer arena.deinit();
+            const allocator = arena.allocator();
+            const args = try std.process.argsAlloc(allocator);
+            try run(allocator, args, {});
+        }
+
+        fn mainV16(init: std.process.Init) !void {
+            var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer arena.deinit();
+            const allocator = arena.allocator();
+            const args = try collectArgs(allocator, init.minimal.args);
+            try run(allocator, args, init.io);
+        }
+
+        pub const main = if (is_v016) mainV16 else mainV15;
+    };
+}
+
+/// Zig 0.16 has no `argsAlloc`; the args arrive via `Init` and must be
+/// collected into a slice. Only reachable on 0.16.
+fn collectArgs(allocator: std.mem.Allocator, args: std.process.Args) ![]const []const u8 {
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer list.deinit(allocator);
+    var it = std.process.Args.Iterator.init(args);
+    while (it.next()) |arg| try list.append(allocator, try allocator.dupe(u8, arg));
+    return list.toOwnedSlice(allocator);
 }

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -651,6 +651,7 @@ fn showDiff(io: compat.Io, allocator: std.mem.Allocator, file_path: []const u8, 
         const stdout_file = std.fs.File.stdout();
         var stdout_w = stdout_file.writer(&obuf);
         stdout_w.interface.writeAll(diff) catch return;
+        stdout_w.interface.flush() catch return;
     }
 }
 

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -2,6 +2,8 @@
 
 const std = @import("std");
 
+const compat = @import("compat.zig");
+
 pub const version = "0.1.0";
 
 pub const class_std_builtin: u2 = 0;
@@ -94,7 +96,7 @@ fn findCommentStart(source: []const u8, line_start: usize) ?usize {
     while (true) {
         const prev_start = findLineStart(source, back);
         const prev_end = findLineEnd(source, prev_start);
-        const prev_trimmed = std.mem.trimLeft(u8, source[prev_start..prev_end], " \t\r");
+        const prev_trimmed = std.mem.trimStart(u8, source[prev_start..prev_end], " \t\r");
         if (prev_trimmed.len == 0 or std.mem.startsWith(u8, prev_trimmed, "//")) {
             comment_start = prev_start;
             if (prev_start == 0) return null;
@@ -153,14 +155,14 @@ pub fn extractPath(source: []const u8, needle: []const u8) ?[]const u8 {
 fn endsWithSemicolon(trimmed: []const u8) bool {
     var t = trimmed;
     if (std.mem.indexOf(u8, t, "//")) |c| t = t[0..c];
-    t = std.mem.trimRight(u8, t, " \t\r\n");
+    t = std.mem.trimEnd(u8, t, " \t\r\n");
     return t.len > 0 and t[t.len - 1] == ';';
 }
 
 // only the first token after = is a type keyword; trailing comment/string text must not count
 fn hasTypeKeyword(trimmed: []const u8, keyword: []const u8) bool {
     const eq = std.mem.indexOfScalar(u8, trimmed, '=') orelse return false;
-    const rhs = std.mem.trimLeft(u8, trimmed[eq + 1 ..], " \t");
+    const rhs = std.mem.trimStart(u8, trimmed[eq + 1 ..], " \t");
     if (!std.mem.startsWith(u8, rhs, keyword)) return false;
     const after = keyword.len;
     return after >= rhs.len or
@@ -168,7 +170,7 @@ fn hasTypeKeyword(trimmed: []const u8, keyword: []const u8) bool {
 }
 
 pub fn isTopLevelImportLine(line: []const u8) bool {
-    const trimmed = std.mem.trimLeft(u8, line, " \t\n\r");
+    const trimmed = std.mem.trimStart(u8, line, " \t\n\r");
     if (trimmed.len == 0) return true;
     if (std.mem.startsWith(u8, trimmed, "//")) return true;
 
@@ -238,7 +240,7 @@ pub fn collectImports(
             const found = i;
             const line_start = findLineStart(source, found);
             const line_end = findLineEnd(source, found);
-            const line = std.mem.trimLeft(u8, source[line_start..line_end], " \t\r");
+            const line = std.mem.trimStart(u8, source[line_start..line_end], " \t\r");
             if (!std.mem.startsWith(u8, line, "const ") and
                 !std.mem.startsWith(u8, line, "pub const ") and
                 !std.mem.startsWith(u8, line, "_ = @import"))
@@ -350,7 +352,7 @@ pub fn hasBannedPatterns(
             const found = i;
             const line_start = findLineStart(source, found);
             const line_end_excl = findLineEnd(source, found);
-            const line = std.mem.trimLeft(u8, source[line_start..line_end_excl], " \t\r");
+            const line = std.mem.trimStart(u8, source[line_start..line_end_excl], " \t\r");
 
             if (!std.mem.startsWith(u8, line, "const ") and
                 !std.mem.startsWith(u8, line, "pub const ") and
@@ -411,7 +413,7 @@ pub fn buildSortedImportText(
     while (pos < block_end) {
         const le = findLineEnd(source, pos);
         const line = source[pos..le];
-        const trimmed = std.mem.trimLeft(u8, line, " \t\n\r");
+        const trimmed = std.mem.trimStart(u8, line, " \t\n\r");
         if (trimmed.len == 0 or std.mem.startsWith(u8, trimmed, "//")) {
             if (!seen_content) {
                 try preamble_lines.append(allocator, line);
@@ -572,7 +574,7 @@ fn splitLines(allocator: std.mem.Allocator, text: []const u8) !std.ArrayListUnma
     var lines: std.ArrayListUnmanaged([]const u8) = .empty;
     var it = std.mem.splitScalar(u8, text, '\n');
     while (it.next()) |line| {
-        try lines.append(allocator, std.mem.trimRight(u8, line, "\r"));
+        try lines.append(allocator, std.mem.trimEnd(u8, line, "\r"));
     }
     // A trailing newline produces a final empty element; drop it so that
     // "a\n" and "a" compare equal.
@@ -613,13 +615,15 @@ pub fn formatUnifiedDiff(
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var w = compat.ListWriter.init(allocator, &buf);
+    errdefer buf = w.toArrayList();
 
     if (old_mid.len == 0 and new_mid.len == 0) {
         try w.print("  --- {s}\n", .{file_path});
         try w.print("  +++ {s}\n", .{file_path});
         try w.print("  (trailing newline only)\n", .{});
         try w.writeByte('\n');
+        buf = w.toArrayList();
         return buf.toOwnedSlice(allocator);
     }
 
@@ -631,16 +635,23 @@ pub fn formatUnifiedDiff(
     for (new_mid) |line| try w.print("  + {s}\n", .{line});
     for (old_lines.items[after_start..after_end]) |line| try w.print("   {s}\n", .{line});
     try w.writeByte('\n');
+    buf = w.toArrayList();
     return buf.toOwnedSlice(allocator);
 }
 
-fn showDiff(allocator: std.mem.Allocator, file_path: []const u8, old: []const u8, new: []const u8) void {
+fn showDiff(io: compat.Io, allocator: std.mem.Allocator, file_path: []const u8, old: []const u8, new: []const u8) void {
     const diff = formatUnifiedDiff(allocator, file_path, old, new) catch return;
-    var obuf: [4096]u8 = undefined;
-    const stdout_file = std.fs.File.stdout();
-    var stdout_w = stdout_file.writer(&obuf);
-    stdout_w.interface.writeAll(diff) catch return;
-    stdout_w.interface.flush() catch return;
+    if (compat.is_v016) {
+        var obuf: [4096]u8 = undefined;
+        var stdout_w = std.Io.File.stdout().writer(io, &obuf);
+        stdout_w.interface.writeAll(diff) catch return;
+        stdout_w.flush() catch return;
+    } else {
+        var obuf: [4096]u8 = undefined;
+        const stdout_file = std.fs.File.stdout();
+        var stdout_w = stdout_file.writer(&obuf);
+        stdout_w.interface.writeAll(diff) catch return;
+    }
 }
 
 const excluded_dirs = [_][]const u8{ ".git", ".zig-cache", "zig-cache", "zig-out" };
@@ -660,7 +671,7 @@ fn isExcludedPath(path: []const u8) bool {
 /// but not `build-tools/x.zig`). A pattern containing a slash is anchored at the
 /// path root. A trailing slash in `pattern` is ignored.
 pub fn matchesIgnore(path: []const u8, pattern: []const u8) bool {
-    const pat = std.mem.trimRight(u8, pattern, "/");
+    const pat = std.mem.trimEnd(u8, pattern, "/");
     if (pat.len == 0) return false;
     if (std.mem.indexOfScalar(u8, pat, '/') != null) {
         return matchesComponentPrefix(path, pat);
@@ -684,15 +695,12 @@ fn matchesAnyIgnore(path: []const u8, ignores: []const []const u8) bool {
     return false;
 }
 
-/// Read `<root>/.gitignore` and return its cleaned patterns, allocated with
+/// Read `<dir>/.gitignore` and return its cleaned patterns, allocated with
 /// `allocator` (patterns and the slice belong to that allocator).
 /// Missing or unreadable files yield an empty list (not an error).
 /// ponytail: no wildcards or negation; entries match as path-component prefixes
-pub fn loadGitignore(allocator: std.mem.Allocator, root: []const u8) ![]const []const u8 {
-    const gitignore_path = try std.fs.path.join(allocator, &.{ root, ".gitignore" });
-    defer allocator.free(gitignore_path);
-
-    const contents = std.fs.cwd().readFileAlloc(allocator, gitignore_path, 1024 * 1024) catch return &[_][]const u8{};
+pub fn loadGitignore(io: compat.Io, allocator: std.mem.Allocator, dir: compat.Dir) ![]const []const u8 {
+    const contents = compat.readFileAlloc(io, dir, ".gitignore", allocator, 1024 * 1024) catch return &[_][]const u8{};
     defer allocator.free(contents);
 
     var patterns: std.ArrayListUnmanaged([]const u8) = .empty;
@@ -709,33 +717,35 @@ pub fn loadGitignore(allocator: std.mem.Allocator, root: []const u8) ![]const []
 }
 
 pub fn walkDir(
+    io: compat.Io,
     allocator: std.mem.Allocator,
-    dir: std.fs.Dir,
+    dir: compat.Dir,
     base_path: []const u8,
     files: *std.ArrayListUnmanaged([]const u8),
     ignores: []const []const u8,
 ) !void {
     const Item = struct {
-        iter: std.fs.Dir.Iterator,
+        dir: compat.Dir,
+        iter: compat.Iterator,
         rel_len: usize,
     };
     var stack: std.ArrayListUnmanaged(Item) = .empty;
     var name_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer {
         if (stack.items.len > 1) {
-            for (stack.items[1..]) |*item| item.iter.dir.close();
+            for (stack.items[1..]) |*item| compat.close(io, &item.dir);
         }
         stack.deinit(allocator);
         name_buf.deinit(allocator);
     }
 
-    try stack.append(allocator, .{ .iter = dir.iterate(), .rel_len = 0 });
+    try stack.append(allocator, .{ .dir = dir, .iter = compat.iterate(dir), .rel_len = 0 });
 
     while (stack.items.len != 0) {
         const top = &stack.items[stack.items.len - 1];
-        const entry = try top.iter.next() orelse {
+        const entry = try compat.next(io, &top.iter) orelse {
             var item = stack.pop().?;
-            if (stack.items.len != 0) item.iter.dir.close();
+            if (stack.items.len != 0) compat.close(io, &item.dir);
             continue;
         };
         name_buf.shrinkRetainingCapacity(top.rel_len);
@@ -747,9 +757,9 @@ pub fn walkDir(
             .directory => {
                 if (isExcludedPath(rel)) continue;
                 if (matchesAnyIgnore(rel, ignores)) continue;
-                var sub = try top.iter.dir.openDir(entry.name, .{ .iterate = true });
-                errdefer sub.close();
-                try stack.append(allocator, .{ .iter = sub.iterateAssumeFirstIteration(), .rel_len = name_buf.items.len });
+                var sub = try compat.openDir(io, top.dir, entry.name, .{ .iterate = true });
+                errdefer compat.close(io, &sub);
+                try stack.append(allocator, .{ .dir = sub, .iter = compat.iterate(sub), .rel_len = name_buf.items.len });
             },
             .file => {
                 if (isExcludedPath(rel)) continue;
@@ -767,7 +777,7 @@ fn hasSkipComment(source: []const u8) bool {
     var pos: usize = 0;
     while (pos < source.len) {
         const le = findLineEnd(source, pos);
-        const trimmed = std.mem.trimLeft(u8, source[pos..le], " \t\r");
+        const trimmed = std.mem.trimStart(u8, source[pos..le], " \t\r");
         if (std.mem.startsWith(u8, trimmed, "//") and std.mem.indexOf(u8, trimmed, "zsort: skip") != null) {
             return true;
         }
@@ -953,14 +963,24 @@ pub fn parseArgs(
     };
 }
 
-fn printStdout(comptime fmt: []const u8, args: anytype) void {
-    var obuf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&obuf);
-    w.interface.print(fmt, args) catch return;
-    w.interface.flush() catch return;
+fn printStdout(io: compat.Io, comptime fmt: []const u8, args: anytype) void {
+    if (compat.is_v016) {
+        var obuf: [4096]u8 = undefined;
+        var w = std.Io.File.stdout().writer(io, &obuf);
+        w.interface.print(fmt, args) catch return;
+        w.flush() catch return;
+    } else {
+        var obuf: [4096]u8 = undefined;
+        var w = std.fs.File.stdout().writer(&obuf);
+        w.interface.print(fmt, args) catch return;
+        w.interface.flush() catch return;
+    }
 }
 
-fn useColor() bool {
+fn useColor(io: compat.Io) bool {
+    if (compat.is_v016) {
+        return std.Io.File.isTty(std.Io.File.stdout(), io) catch return false;
+    }
     return std.posix.isatty(std.fs.File.stdout().handle);
 }
 
@@ -993,8 +1013,8 @@ pub fn formatSummary(
     };
 }
 
-fn printHelp() void {
-    printStdout(
+fn printHelp(io: compat.Io) void {
+    printStdout(io,
         \\Usage: zsort [check|fix] <dir|file> [options]
         \\
         \\Modes:
@@ -1023,9 +1043,9 @@ const FileJob = struct {
     banned: []const []const u8,
 };
 
-fn processFileJob(job: *const FileJob) void {
+fn processFileJob(job: *const FileJob, io: compat.Io) void {
     const allocator = job.slot.arena.allocator();
-    const source = std.fs.cwd().readFileAlloc(allocator, job.path, 10 * 1024 * 1024) catch |err| {
+    const source = compat.readFileAlloc(io, compat.cwd(), job.path, allocator, 10 * 1024 * 1024) catch |err| {
         job.slot.read_err = @errorName(err);
         return;
     };
@@ -1036,12 +1056,38 @@ fn processFileJob(job: *const FileJob) void {
     };
 }
 
-pub fn main() !void {
+fn mainV15() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
     const args = try std.process.argsAlloc(allocator);
+    const io: compat.Io = {};
+    try runMain(allocator, args, io);
+}
+
+fn mainV16(init: std.process.Init) !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const args = try collectArgs(allocator, init.minimal.args);
+    try runMain(allocator, args, init.io);
+}
+
+pub const main = if (compat.is_v016) mainV16 else mainV15;
+
+/// Zig 0.16 has no `argsAlloc`; the args arrive via `Init` and must be
+/// collected into a slice.
+fn collectArgs(allocator: std.mem.Allocator, args: std.process.Args) ![]const []const u8 {
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer list.deinit(allocator);
+    var it = std.process.Args.Iterator.init(args);
+    while (it.next()) |arg| try list.append(allocator, try allocator.dupe(u8, arg));
+    return list.toOwnedSlice(allocator);
+}
+
+fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io) !void {
     var err_msg: ?[]const u8 = null;
     var parsed = parseArgs(allocator, args, &err_msg) catch |e| switch (e) {
         error.Usage => {
@@ -1066,27 +1112,27 @@ pub fn main() !void {
     defer parsed.deinit(allocator);
 
     if (parsed.help) {
-        printHelp();
+        printHelp(io);
         return;
     }
     if (parsed.version) {
-        printStdout("zsort {s}\n", .{version});
+        printStdout(io, "zsort {s}\n", .{version});
         return;
     }
 
     var files: std.ArrayListUnmanaged([]const u8) = .empty;
     defer files.deinit(allocator);
 
-    const stat = std.fs.cwd().statFile(parsed.target) catch |err| {
+    const stat = compat.statFile(io, compat.cwd(), parsed.target) catch |err| {
         std.debug.print("Cannot access '{s}': {s}\n", .{ parsed.target, @errorName(err) });
         std.process.exit(1);
     };
 
     if (stat.kind == .directory) {
-        var dir = try std.fs.cwd().openDir(parsed.target, .{ .iterate = true });
-        defer dir.close();
-        const ignores = try loadGitignore(allocator, parsed.target);
-        try walkDir(allocator, dir, parsed.target, &files, ignores);
+        var dir = try compat.openDir(io, compat.cwd(), parsed.target, .{ .iterate = true });
+        defer compat.close(io, &dir);
+        const ignores = try loadGitignore(io, allocator, dir);
+        try walkDir(io, allocator, dir, parsed.target, &files, ignores);
     } else if (stat.kind == .file) {
         try files.append(allocator, parsed.target);
     } else {
@@ -1099,7 +1145,7 @@ pub fn main() !void {
         std.process.exit(1);
     }
 
-    var timer = try std.time.Timer.start();
+    var timer = try compat.Timer.start(io);
 
     const slots = try allocator.alloc(JobSlot, files.items.len);
     defer allocator.free(slots);
@@ -1125,14 +1171,18 @@ pub fn main() !void {
     }
 
     // SAFETY: init() fully initializes the pool before any use below.
-    var pool: std.Thread.Pool = undefined;
-    try std.Thread.Pool.init(&pool, .{ .allocator = allocator, .n_jobs = null });
-    defer pool.deinit();
-    var wg: std.Thread.WaitGroup = .{};
-    for (jobs) |*job| {
-        pool.spawnWg(&wg, processFileJob, .{job});
+    if (compat.is_v016) {
+        var g: std.Io.Group = .init;
+        for (jobs) |*job| g.async(io, processFileJob, .{ job, io });
+        try g.await(io);
+    } else {
+        var pool: std.Thread.Pool = undefined;
+        try std.Thread.Pool.init(&pool, .{ .allocator = allocator, .n_jobs = null });
+        defer pool.deinit();
+        var wg: std.Thread.WaitGroup = .{};
+        for (jobs) |*job| pool.spawnWg(&wg, processFileJob, .{ job, {} });
+        pool.waitAndWork(&wg);
     }
-    pool.waitAndWork(&wg);
 
     var changed_count: usize = 0;
     var fixed_count: usize = 0;
@@ -1166,31 +1216,19 @@ pub fn main() !void {
 
         if (parsed.mode == .fix) {
             fixFile: {
-                var af_buf: [4096]u8 = undefined;
-                var af = std.fs.cwd().atomicFile(file_path, .{ .write_buffer = &af_buf }) catch |err| {
-                    std.debug.print("Error writing {s}: {s}\n", .{ file_path, @errorName(err) });
-                    error_count += 1;
-                    break :fixFile;
-                };
-                defer af.deinit();
-                af.file_writer.interface.writeAll(result.new_text) catch |err| {
-                    std.debug.print("Error writing {s}: {s}\n", .{ file_path, @errorName(err) });
-                    error_count += 1;
-                    break :fixFile;
-                };
-                af.finish() catch |err| {
+                compat.atomicWrite(io, compat.cwd(), file_path, result.new_text) catch |err| {
                     std.debug.print("Error writing {s}: {s}\n", .{ file_path, @errorName(err) });
                     error_count += 1;
                     break :fixFile;
                 };
                 fixed_count += 1;
-                printStdout("Fixed: {s}\n", .{file_path});
+                printStdout(io, "Fixed: {s}\n", .{file_path});
             }
         } else {
             if (result.stray_count > 0) {
-                showDiff(allocator, file_path, slot.source, result.new_text);
+                showDiff(io, allocator, file_path, slot.source, result.new_text);
             } else {
-                showDiff(allocator, file_path, slot.source[0..result.block_end], result.new_block);
+                showDiff(io, allocator, file_path, slot.source[0..result.block_end], result.new_block);
             }
         }
     }
@@ -1203,15 +1241,15 @@ pub fn main() !void {
         .elapsed_ns = timer.read(),
     };
     if (parsed.mode == .check) {
-        if (formatSummary(allocator, stats, .check, useColor())) |summary| {
-            printStdout("{s}", .{summary});
+        if (formatSummary(allocator, stats, .check, useColor(io))) |summary| {
+            printStdout(io, "{s}", .{summary});
         }
         if (changed_count > 0 or error_count > 0 or banned_count > 0) {
             std.process.exit(1);
         }
     } else {
-        if (formatSummary(allocator, stats, .fix, useColor())) |summary| {
-            printStdout("{s}", .{summary});
+        if (formatSummary(allocator, stats, .fix, useColor(io))) |summary| {
+            printStdout(io, "{s}", .{summary});
         }
         if (error_count > 0 or banned_count > 0) std.process.exit(1);
     }

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -615,15 +615,16 @@ pub fn formatUnifiedDiff(
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
-    var w = compat.ListWriter.init(allocator, &buf);
-    errdefer buf = w.toArrayList();
+    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
+    errdefer buf = aw.toArrayList();
+    const w = &aw.writer;
 
     if (old_mid.len == 0 and new_mid.len == 0) {
         try w.print("  --- {s}\n", .{file_path});
         try w.print("  +++ {s}\n", .{file_path});
         try w.print("  (trailing newline only)\n", .{});
         try w.writeByte('\n');
-        buf = w.toArrayList();
+        buf = aw.toArrayList();
         return buf.toOwnedSlice(allocator);
     }
 
@@ -635,24 +636,13 @@ pub fn formatUnifiedDiff(
     for (new_mid) |line| try w.print("  + {s}\n", .{line});
     for (old_lines.items[after_start..after_end]) |line| try w.print("   {s}\n", .{line});
     try w.writeByte('\n');
-    buf = w.toArrayList();
+    buf = aw.toArrayList();
     return buf.toOwnedSlice(allocator);
 }
 
 fn showDiff(io: compat.Io, allocator: std.mem.Allocator, file_path: []const u8, old: []const u8, new: []const u8) void {
     const diff = formatUnifiedDiff(allocator, file_path, old, new) catch return;
-    if (compat.is_v016) {
-        var obuf: [4096]u8 = undefined;
-        var stdout_w = std.Io.File.stdout().writer(io, &obuf);
-        stdout_w.interface.writeAll(diff) catch return;
-        stdout_w.flush() catch return;
-    } else {
-        var obuf: [4096]u8 = undefined;
-        const stdout_file = std.fs.File.stdout();
-        var stdout_w = stdout_file.writer(&obuf);
-        stdout_w.interface.writeAll(diff) catch return;
-        stdout_w.interface.flush() catch return;
-    }
+    compat.writeStdout(io, diff);
 }
 
 const excluded_dirs = [_][]const u8{ ".git", ".zig-cache", "zig-cache", "zig-out" };
@@ -964,27 +954,6 @@ pub fn parseArgs(
     };
 }
 
-fn printStdout(io: compat.Io, comptime fmt: []const u8, args: anytype) void {
-    if (compat.is_v016) {
-        var obuf: [4096]u8 = undefined;
-        var w = std.Io.File.stdout().writer(io, &obuf);
-        w.interface.print(fmt, args) catch return;
-        w.flush() catch return;
-    } else {
-        var obuf: [4096]u8 = undefined;
-        var w = std.fs.File.stdout().writer(&obuf);
-        w.interface.print(fmt, args) catch return;
-        w.interface.flush() catch return;
-    }
-}
-
-fn useColor(io: compat.Io) bool {
-    if (compat.is_v016) {
-        return std.Io.File.isTty(std.Io.File.stdout(), io) catch return false;
-    }
-    return std.posix.isatty(std.fs.File.stdout().handle);
-}
-
 pub const SummaryStats = struct {
     changed: usize,
     errors: usize,
@@ -1015,7 +984,7 @@ pub fn formatSummary(
 }
 
 fn printHelp(io: compat.Io) void {
-    printStdout(io,
+    compat.printStdout(io,
         \\Usage: zsort [check|fix] <dir|file> [options]
         \\
         \\Modes:
@@ -1057,36 +1026,7 @@ fn processFileJob(job: *const FileJob, io: compat.Io) void {
     };
 }
 
-fn mainV15() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const args = try std.process.argsAlloc(allocator);
-    const io: compat.Io = {};
-    try runMain(allocator, args, io);
-}
-
-fn mainV16(init: std.process.Init) !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const args = try collectArgs(allocator, init.minimal.args);
-    try runMain(allocator, args, init.io);
-}
-
-pub const main = if (compat.is_v016) mainV16 else mainV15;
-
-/// Zig 0.16 has no `argsAlloc`; the args arrive via `Init` and must be
-/// collected into a slice.
-fn collectArgs(allocator: std.mem.Allocator, args: std.process.Args) ![]const []const u8 {
-    var list: std.ArrayListUnmanaged([]const u8) = .empty;
-    errdefer list.deinit(allocator);
-    var it = std.process.Args.Iterator.init(args);
-    while (it.next()) |arg| try list.append(allocator, try allocator.dupe(u8, arg));
-    return list.toOwnedSlice(allocator);
-}
+pub const main = compat.entry(runMain).main;
 
 fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io) !void {
     var err_msg: ?[]const u8 = null;
@@ -1117,7 +1057,7 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
         return;
     }
     if (parsed.version) {
-        printStdout(io, "zsort {s}\n", .{version});
+        compat.printStdout(io, "zsort {s}\n", .{version});
         return;
     }
 
@@ -1171,19 +1111,7 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
         };
     }
 
-    // SAFETY: init() fully initializes the pool before any use below.
-    if (compat.is_v016) {
-        var g: std.Io.Group = .init;
-        for (jobs) |*job| g.async(io, processFileJob, .{ job, io });
-        try g.await(io);
-    } else {
-        var pool: std.Thread.Pool = undefined;
-        try std.Thread.Pool.init(&pool, .{ .allocator = allocator, .n_jobs = null });
-        defer pool.deinit();
-        var wg: std.Thread.WaitGroup = .{};
-        for (jobs) |*job| pool.spawnWg(&wg, processFileJob, .{ job, {} });
-        pool.waitAndWork(&wg);
-    }
+    try compat.runParallel(io, allocator, FileJob, processFileJob, jobs);
 
     var changed_count: usize = 0;
     var fixed_count: usize = 0;
@@ -1223,7 +1151,7 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
                     break :fixFile;
                 };
                 fixed_count += 1;
-                printStdout(io, "Fixed: {s}\n", .{file_path});
+                compat.printStdout(io, "Fixed: {s}\n", .{file_path});
             }
         } else {
             if (result.stray_count > 0) {
@@ -1242,15 +1170,15 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
         .elapsed_ns = timer.read(),
     };
     if (parsed.mode == .check) {
-        if (formatSummary(allocator, stats, .check, useColor(io))) |summary| {
-            printStdout(io, "{s}", .{summary});
+        if (formatSummary(allocator, stats, .check, compat.isTty(io))) |summary| {
+            compat.printStdout(io, "{s}", .{summary});
         }
         if (changed_count > 0 or error_count > 0 or banned_count > 0) {
             std.process.exit(1);
         }
     } else {
-        if (formatSummary(allocator, stats, .fix, useColor(io))) |summary| {
-            printStdout(io, "{s}", .{summary});
+        if (formatSummary(allocator, stats, .fix, compat.isTty(io))) |summary| {
+            compat.printStdout(io, "{s}", .{summary});
         }
         if (error_count > 0 or banned_count > 0) std.process.exit(1);
     }

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const compat = @import("compat.zig");
 const zsort = @import("zsort.zig");
 
 test "classify: std/builtin" {
@@ -450,25 +451,25 @@ test "processSource: preserves CRLF line endings" {
 test "walkDir: excludes cache and vcs directories" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
-    try tmp.dir.makePath(".git");
-    try tmp.dir.makePath(".zig-cache");
-    try tmp.dir.makePath("zig-cache");
-    try tmp.dir.makePath("zig-out");
-    try tmp.dir.makePath("sub");
-    try tmp.dir.makePath("sub/.zig-cache");
-    try tmp.dir.writeFile(.{ .sub_path = "main.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "sub/lib.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "sub/.zig-cache/e.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = ".git/a.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = ".zig-cache/b.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "zig-cache/c.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "zig-out/d.zig", .data = "" });
+    try compat.makePath(compat.testIo(), tmp.dir, ".git");
+    try compat.makePath(compat.testIo(), tmp.dir, ".zig-cache");
+    try compat.makePath(compat.testIo(), tmp.dir, "zig-cache");
+    try compat.makePath(compat.testIo(), tmp.dir, "zig-out");
+    try compat.makePath(compat.testIo(), tmp.dir, "sub");
+    try compat.makePath(compat.testIo(), tmp.dir, "sub/.zig-cache");
+    try compat.writeFile(compat.testIo(), tmp.dir, "main.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "sub/lib.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "sub/.zig-cache/e.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, ".git/a.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, ".zig-cache/b.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "zig-cache/c.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "zig-out/d.zig", "");
     var found: std.ArrayListUnmanaged([]const u8) = .empty;
     defer {
         for (found.items) |f| std.testing.allocator.free(f);
         found.deinit(std.testing.allocator);
     }
-    try zsort.walkDir(std.testing.allocator, tmp.dir, "tmp", &found, &.{});
+    try zsort.walkDir(compat.testIo(), std.testing.allocator, tmp.dir, "tmp", &found, &.{});
     try std.testing.expectEqual(@as(usize, 2), found.items.len);
     for (found.items) |f| {
         try std.testing.expect(std.mem.endsWith(u8, f, "main.zig") or std.mem.endsWith(u8, f, "sub/lib.zig"));
@@ -478,18 +479,18 @@ test "walkDir: excludes cache and vcs directories" {
 test "walkDir: respects gitignore ignores at component boundaries" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
-    try tmp.dir.makePath("ignored");
-    try tmp.dir.makePath("build-tools");
-    try tmp.dir.makePath("keep");
-    try tmp.dir.writeFile(.{ .sub_path = "ignored/a.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "build-tools/b.zig", .data = "" });
-    try tmp.dir.writeFile(.{ .sub_path = "keep/c.zig", .data = "" });
+    try compat.makePath(compat.testIo(), tmp.dir, "ignored");
+    try compat.makePath(compat.testIo(), tmp.dir, "build-tools");
+    try compat.makePath(compat.testIo(), tmp.dir, "keep");
+    try compat.writeFile(compat.testIo(), tmp.dir, "ignored/a.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "build-tools/b.zig", "");
+    try compat.writeFile(compat.testIo(), tmp.dir, "keep/c.zig", "");
     var found: std.ArrayListUnmanaged([]const u8) = .empty;
     defer {
         for (found.items) |f| std.testing.allocator.free(f);
         found.deinit(std.testing.allocator);
     }
-    try zsort.walkDir(std.testing.allocator, tmp.dir, "tmp", &found, &.{ "ignored", "build" });
+    try zsort.walkDir(compat.testIo(), std.testing.allocator, tmp.dir, "tmp", &found, &.{ "ignored", "build" });
     try std.testing.expectEqual(@as(usize, 2), found.items.len);
     for (found.items) |f| {
         try std.testing.expect(std.mem.endsWith(u8, f, "build-tools/b.zig") or std.mem.endsWith(u8, f, "keep/c.zig"));
@@ -514,13 +515,8 @@ test "matchesIgnore: component-boundary prefix match" {
 test "loadGitignore: parses patterns, skips comments and unsupported entries" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
-    try tmp.dir.writeFile(.{
-        .sub_path = ".gitignore",
-        .data = "# comment\n.zig-cache\nbuild/\n\n*.tmp\n!keep\nnode_modules\n  spaced  \n",
-    });
-    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
-    defer std.testing.allocator.free(root);
-    const ignores = try zsort.loadGitignore(std.testing.allocator, root);
+    try compat.writeFile(compat.testIo(), tmp.dir, ".gitignore", "# comment\n.zig-cache\nbuild/\n\n*.tmp\n!keep\nnode_modules\n  spaced  \n");
+    const ignores = try zsort.loadGitignore(compat.testIo(), std.testing.allocator, tmp.dir);
     defer {
         for (ignores) |p| std.testing.allocator.free(p);
         std.testing.allocator.free(ignores);
@@ -535,9 +531,7 @@ test "loadGitignore: parses patterns, skips comments and unsupported entries" {
 test "loadGitignore: missing file yields empty list" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
-    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
-    defer std.testing.allocator.free(root);
-    const ignores = try zsort.loadGitignore(std.testing.allocator, root);
+    const ignores = try zsort.loadGitignore(compat.testIo(), std.testing.allocator, tmp.dir);
     defer std.testing.allocator.free(ignores);
     try std.testing.expectEqual(@as(usize, 0), ignores.len);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Added support for Zig 0.15 and Zig 0.16.
  * Updated file handling, directory traversal, timers, terminal output, and parallel processing across supported compiler versions.

* **Build & Maintenance**
  * Adjusted linting behavior for different Zig compiler versions.
  * Excluded generated package files from version control.

* **Testing**
  * Updated filesystem-related tests to work consistently across supported Zig versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->