### PR TITLE
Replace handrolled scan with AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ moved as a whole.
 ### What `fix` does
 
 - Sorts and groups top-of-file imports
+- Organizes typed imports (`const x: SomeType = @import(...)`) like plain ones
 - Hoists imports that appear later in the file into their proper group
 - Keeps comments that immediately precede an import attached to it
 - Preserves `//!` module documentation and the file's line endings (CRLF kept)

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -84,10 +84,16 @@ pub const Analysis = struct {
     imports: std.ArrayListUnmanaged(Import) = .empty,
     aliases: std.ArrayListUnmanaged(Import) = .empty,
     block_end: usize = 0,
+    /// Every `@import` call in the tree (offset + path), for banned checks.
+    calls: std.ArrayListUnmanaged(ImportCall) = .empty,
+    /// Offsets of `calls` that head a `const` decl initializer (not inline).
+    allowed: std.ArrayListUnmanaged(usize) = .empty,
 
     pub fn deinit(self: *Analysis, allocator: std.mem.Allocator) void {
         self.imports.deinit(allocator);
         self.aliases.deinit(allocator);
+        self.calls.deinit(allocator);
+        self.allowed.deinit(allocator);
     }
 };
 
@@ -124,6 +130,9 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
 
     result.block_end = lineBlockEnd(source, result.imports.items, result.aliases.items);
 
+    result.calls = try importCalls(allocator, tree);
+    result.allowed = try collectAllowedOffsets(allocator, tree);
+
     // Aliases outside the block are left alone (never hoisted).
     var j: usize = 0;
     while (j < result.aliases.items.len) {
@@ -137,6 +146,44 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
     for (result.imports.items) |*imp| imp.stray = imp.start >= result.block_end;
     std.sort.pdq(Import, result.imports.items, {}, Import.lessThan);
     return result;
+}
+
+/// Offsets of every `@import` call that heads a `const` declaration's
+/// initializer, at any nesting depth (direct call or leading dotted chain).
+fn collectAllowedOffsets(allocator: std.mem.Allocator, tree: Ast) !std.ArrayListUnmanaged(usize) {
+    var allowed: std.ArrayListUnmanaged(usize) = .empty;
+    errdefer allowed.deinit(allocator);
+    var i: u32 = 0;
+    while (i < tree.nodes.len) : (i += 1) {
+        const node: Ast.Node.Index = @enumFromInt(i);
+        const vd: ?Ast.full.VarDecl = switch (tree.nodeTag(node)) {
+            .simple_var_decl => tree.simpleVarDecl(node),
+            .local_var_decl => tree.localVarDecl(node),
+            .global_var_decl => tree.globalVarDecl(node),
+            .aligned_var_decl => tree.alignedVarDecl(node),
+            else => null,
+        };
+        const decl = vd orelse continue;
+        if (!std.mem.eql(u8, tree.tokenSlice(decl.ast.mut_token), "const")) continue;
+        const init = decl.ast.init_node.unwrap() orelse continue;
+        if (importHeadOffset(tree, init)) |off| try allowed.append(allocator, off);
+    }
+    return allowed;
+}
+
+/// Offset of the `@import` call heading `init`: `@import("a")` itself, or the
+/// base of a dotted chain like `@import("a").Foo.Bar`.
+fn importHeadOffset(tree: Ast, init: Ast.Node.Index) ?usize {
+    var cur = init;
+    while (tree.nodeTag(cur) == .field_access) {
+        cur = tree.nodeData(cur).node_and_token[0];
+    }
+    switch (tree.nodeTag(cur)) {
+        .builtin_call, .builtin_call_comma, .builtin_call_two, .builtin_call_two_comma => {},
+        else => return null,
+    }
+    if (!std.mem.eql(u8, tree.tokenSlice(tree.firstToken(cur)), "@import")) return null;
+    return tree.tokens.items(.start)[tree.firstToken(cur)];
 }
 
 /// The import block ends at the first line that is not blank, a comment, or
@@ -285,12 +332,15 @@ fn declStart(tree: Ast, node: Ast.Node.Index) usize {
 /// inline comments travel with the import.
 fn spanEnd(tree: Ast, source: []const u8, node: Ast.Node.Index) usize {
     const eof_idx = tree.tokens.len - 1;
-    var t: u32 = tree.lastToken(node);
+    const last_node_token = tree.lastToken(node);
+    var t: u32 = last_node_token;
     while (t < eof_idx) : (t += 1) {
         if (tree.tokens.items(.tag)[t] == .semicolon) {
             return findLineEnd(source, tree.tokens.items(.start)[t]);
         }
+        // Do not cross into a later declaration.
+        if (t > last_node_token and !tree.tokensOnSameLine(last_node_token, t)) break;
     }
-    const last = t - 1;
+    const last = if (t > 0) t - 1 else 0;
     return findLineEnd(source, tree.tokens.items(.start)[last] + @as(u32, @intCast(tree.tokenSlice(last).len)));
 }

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -1,0 +1,296 @@
+//! Import/alias discovery over `std.zig.Ast`, replacing the previous
+//! hand-rolled scanner. Tolerates malformed input the same way it did:
+//! parse errors never stop collection (error recovery drops broken decls),
+//! invalid tokens reset at the next newline, and plain `//` comments emit
+//! no tokens so they are invisible to every rule here.
+
+const std = @import("std");
+
+pub const class_std_builtin: u2 = 0;
+pub const class_third_party: u2 = 1;
+pub const class_local: u2 = 2;
+
+pub const Import = struct {
+    start: usize,
+    end: usize,
+    path: []const u8,
+    class: u2,
+    stray: bool = false,
+    comment_start: ?usize = null,
+
+    fn lessThan(ctx: void, a: Import, b: Import) bool {
+        _ = ctx;
+        if (a.class != b.class) return a.class < b.class;
+        const cmp = std.mem.order(u8, a.path, b.path);
+        if (cmp != .eq) return cmp == .lt;
+        const a_len = a.end - a.start;
+        const b_len = b.end - b.start;
+        if (a_len != b_len) return a_len < b_len;
+        return a.start < b.start;
+    }
+};
+
+pub fn classify(path: []const u8) u2 {
+    if (std.mem.eql(u8, path, "std") or std.mem.eql(u8, path, "builtin")) {
+        return class_std_builtin;
+    }
+    if (std.mem.eql(u8, path, "root") or std.mem.eql(u8, path, "build_root") or
+        std.mem.indexOfScalar(u8, path, '/') != null or
+        std.mem.endsWith(u8, path, ".zig"))
+    {
+        return class_local;
+    }
+    return class_third_party;
+}
+
+pub fn findLineStart(source: []const u8, pos: usize) usize {
+    var i = pos;
+    while (i > 0) : (i -= 1) {
+        if (source[i - 1] == '\n') return i;
+    }
+    return 0;
+}
+
+pub fn findLineEnd(source: []const u8, pos: usize) usize {
+    var i = pos;
+    while (i < source.len) : (i += 1) {
+        if (source[i] == '\n') return i + 1;
+    }
+    return source.len;
+}
+
+pub fn findCommentStart(source: []const u8, line_start: usize) ?usize {
+    if (line_start == 0) return null;
+    var comment_start: ?usize = null;
+    var back = line_start - 1;
+    while (true) {
+        const prev_start = findLineStart(source, back);
+        const prev_end = findLineEnd(source, prev_start);
+        const prev_trimmed = std.mem.trimStart(u8, source[prev_start..prev_end], " \t\r");
+        if (prev_trimmed.len == 0 or std.mem.startsWith(u8, prev_trimmed, "//")) {
+            comment_start = prev_start;
+            if (prev_start == 0) return null;
+            back = prev_start - 1;
+        } else {
+            break;
+        }
+    }
+    return comment_start;
+}
+
+const Ast = std.zig.Ast;
+
+pub const Analysis = struct {
+    imports: std.ArrayListUnmanaged(Import) = .empty,
+    aliases: std.ArrayListUnmanaged(Import) = .empty,
+    block_end: usize = 0,
+
+    pub fn deinit(self: *Analysis, allocator: std.mem.Allocator) void {
+        self.imports.deinit(allocator);
+        self.aliases.deinit(allocator);
+    }
+};
+
+const Found = struct {
+    imp: Import,
+    alias: bool,
+};
+
+/// `source` must be sentinel-terminated; returned `Import.path` slices point
+/// into it, so it must outlive the analysis.
+pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
+    var tree = try std.zig.Ast.parse(allocator, source, .zig);
+    defer tree.deinit(allocator);
+
+    var result: Analysis = .{};
+    errdefer result.deinit(allocator);
+
+    for (tree.rootDecls()) |node| {
+        const vd: ?Ast.full.VarDecl = switch (tree.nodeTag(node)) {
+            .simple_var_decl => tree.simpleVarDecl(node),
+            .global_var_decl => tree.globalVarDecl(node),
+            .aligned_var_decl => tree.alignedVarDecl(node),
+            else => null,
+        };
+        const found = if (vd) |decl| classifyDecl(tree, source, node, decl) else null;
+        if (found) |f| {
+            if (f.alias) {
+                try result.aliases.append(allocator, f.imp);
+            } else {
+                try result.imports.append(allocator, f.imp);
+            }
+        }
+    }
+
+    result.block_end = lineBlockEnd(source, result.imports.items, result.aliases.items);
+
+    // Aliases outside the block are left alone (never hoisted).
+    var j: usize = 0;
+    while (j < result.aliases.items.len) {
+        if (result.aliases.items[j].start >= result.block_end) {
+            _ = result.aliases.orderedRemove(j);
+        } else {
+            j += 1;
+        }
+    }
+
+    for (result.imports.items) |*imp| imp.stray = imp.start >= result.block_end;
+    std.sort.pdq(Import, result.imports.items, {}, Import.lessThan);
+    return result;
+}
+
+/// The import block ends at the first line that is not blank, a comment, or
+/// covered by a collected import/alias span. Line-based rather than
+/// decl-based so decls the parser dropped under error recovery (unterminated
+/// calls, missing semicolons) are preserved verbatim as trailing text
+/// instead of being swallowed by the rebuilt block.
+fn lineBlockEnd(source: []const u8, imports: []const Import, aliases: []const Import) usize {
+    var pos: usize = 0;
+    while (pos < source.len) {
+        const le = findLineEnd(source, pos);
+        const trimmed = std.mem.trimStart(u8, source[pos..le], " \t\n\r");
+        if (trimmed.len == 0 or std.mem.startsWith(u8, trimmed, "//")) {
+            pos = le;
+            continue;
+        }
+        var covered = false;
+        for (imports) |imp| {
+            if (pos < imp.end and imp.start < le) {
+                covered = true;
+                break;
+            }
+        }
+        if (!covered) for (aliases) |a| {
+            if (pos < a.end and a.start < le) {
+                covered = true;
+                break;
+            }
+        };
+        if (!covered) return pos;
+        pos = le;
+    }
+    return pos;
+}
+
+/// Every `@import` builtin call in the tree, with its source offset and path
+/// (when the argument is a plain string literal). Drives banned-pattern
+/// detection; offsets match `tree.source`.
+pub const ImportCall = struct {
+    offset: usize,
+    path: ?[]const u8,
+};
+
+pub fn importCalls(allocator: std.mem.Allocator, tree: Ast) !std.ArrayListUnmanaged(ImportCall) {
+    var calls: std.ArrayListUnmanaged(ImportCall) = .empty;
+    errdefer calls.deinit(allocator);
+
+    var i: u32 = 0;
+    while (i < tree.nodes.len) : (i += 1) {
+        const node: Ast.Node.Index = @enumFromInt(i);
+        const tag = tree.nodeTag(node);
+        if (tag != .builtin_call and tag != .builtin_call_comma and
+            tag != .builtin_call_two and tag != .builtin_call_two_comma) continue;
+        const name = tree.tokenSlice(tree.firstToken(node));
+        if (!std.mem.eql(u8, name, "@import")) continue;
+        const arg = builtinArg(tree, node);
+        try calls.append(allocator, .{
+            .offset = tree.tokens.items(.start)[tree.firstToken(node)],
+            .path = if (arg) |a| stringPath(tree, a) else null,
+        });
+    }
+    return calls;
+}
+
+fn classifyDecl(tree: Ast, source: []const u8, node: Ast.Node.Index, vd: Ast.full.VarDecl) ?Found {
+    if (!std.mem.eql(u8, tree.tokenSlice(vd.ast.mut_token), "const")) return null;
+    const init = vd.ast.init_node.unwrap() orelse return null;
+    const init_slice = tree.tokenSlice(tree.firstToken(init));
+    const start = declStart(tree, node);
+
+    if (std.mem.eql(u8, init_slice, "@import") or std.mem.eql(u8, init_slice, "@cImport")) {
+        const is_cimport = std.mem.eql(u8, init_slice, "@cImport");
+        const path, const cls = if (is_cimport)
+            .{ "<cimport>", class_third_party }
+        else blk: {
+            const arg = builtinArg(tree, init) orelse return null;
+            const p = stringPath(tree, arg) orelse return null;
+            break :blk .{ p, classify(p) };
+        };
+        return .{ .imp = .{
+            .start = start,
+            .end = spanEnd(tree, source, node),
+            .path = path,
+            .class = cls,
+            .comment_start = findCommentStart(source, findLineStart(source, start)),
+        }, .alias = false };
+    }
+
+    if (tree.nodeTag(init) == .field_access and isAliasChain(tree, init)) {
+        const first = tree.firstToken(init);
+        const last = tree.lastToken(init);
+        const path = source[tree.tokens.items(.start)[first] .. tree.tokens.items(.start)[last] + @as(u32, @intCast(tree.tokenSlice(last).len))];
+        const dot = std.mem.indexOfScalar(u8, path, '.') orelse return null;
+        return .{ .imp = .{
+            .start = start,
+            .end = spanEnd(tree, source, node),
+            .path = path,
+            .class = classify(path[0..dot]),
+            .comment_start = findCommentStart(source, findLineStart(source, start)),
+        }, .alias = true };
+    }
+
+    return null;
+}
+
+/// First argument node of a `builtin_call_two`-family call; zero-arg and
+/// comma-less variants have no argument.
+fn builtinArg(tree: Ast, call: Ast.Node.Index) ?Ast.Node.Index {
+    const args = switch (tree.nodeTag(call)) {
+        .builtin_call_two, .builtin_call_two_comma => tree.nodeData(call).opt_node_and_opt_node,
+        else => return null,
+    };
+    return args[0].unwrap();
+}
+
+fn stringPath(tree: Ast, arg: Ast.Node.Index) ?[]const u8 {
+    if (tree.nodeTag(arg) != .string_literal) return null;
+    const lit = tree.tokenSlice(tree.firstToken(arg));
+    if (lit.len < 2) return null;
+    return lit[1 .. lit.len - 1];
+}
+
+/// Single-line, whitespace-free dotted chain starting with an identifier:
+/// `std.debug`, `a.b.c`. Anything else (spaced dots, multi-line chains,
+/// `@import("a").Foo`, postfix calls) stops the block, like the old
+/// alphanumeric-dot line check did.
+fn isAliasChain(tree: Ast, init: Ast.Node.Index) bool {
+    const first = tree.firstToken(init);
+    const last = tree.lastToken(init);
+    if (tree.tokens.items(.tag)[first] != .identifier) return false;
+    if (!tree.tokensOnSameLine(first, last)) return false;
+    var t = first;
+    while (t < last) : (t += 1) {
+        const end = tree.tokens.items(.start)[t] + @as(u32, @intCast(tree.tokenSlice(t).len));
+        if (end != tree.tokens.items(.start)[t + 1]) return false;
+    }
+    return true;
+}
+
+fn declStart(tree: Ast, node: Ast.Node.Index) usize {
+    return tree.tokens.items(.start)[tree.firstToken(node)];
+}
+
+/// End of an import/alias span: decl nodes exclude the trailing `;`, so
+/// extend to the next `;` token, then to the end of that line so trailing
+/// inline comments travel with the import.
+fn spanEnd(tree: Ast, source: []const u8, node: Ast.Node.Index) usize {
+    const eof_idx = tree.tokens.len - 1;
+    var t: u32 = tree.lastToken(node);
+    while (t < eof_idx) : (t += 1) {
+        if (tree.tokens.items(.tag)[t] == .semicolon) {
+            return findLineEnd(source, tree.tokens.items(.start)[t]);
+        }
+    }
+    const last = t - 1;
+    return findLineEnd(source, tree.tokens.items(.start)[last] + @as(u32, @intCast(tree.tokenSlice(last).len)));
+}

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -254,6 +254,7 @@ pub fn importCalls(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged(
     return calls;
 }
 
+// zwanzig-disable-next-line: unused-parameter
 fn classifyDecl(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]const u8), tree: Ast, source: []const u8, node: Ast.Node.Index, vd: Ast.full.VarDecl) !?Found {
     if (!std.mem.eql(u8, tree.tokenSlice(vd.ast.mut_token), "const")) return null;
     const init = vd.ast.init_node.unwrap() orelse return null;

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -66,7 +66,7 @@ pub fn findCommentStart(source: []const u8, line_start: usize) ?usize {
     while (true) {
         const prev_start = findLineStart(source, back);
         const prev_end = findLineEnd(source, prev_start);
-        const prev_trimmed = std.mem.trimStart(u8, source[prev_start..prev_end], " \t\r");
+        const prev_trimmed = std.mem.trim(u8, source[prev_start..prev_end], " \t\r\n");
         if (prev_trimmed.len == 0 or std.mem.startsWith(u8, prev_trimmed, "//")) {
             comment_start = prev_start;
             if (prev_start == 0) return null;
@@ -88,8 +88,13 @@ pub const Analysis = struct {
     calls: std.ArrayListUnmanaged(ImportCall) = .empty,
     /// Offsets of `calls` that head a `const` decl initializer (not inline).
     allowed: std.ArrayListUnmanaged(usize) = .empty,
+    /// Decoded import paths that no longer slice into `source` (escaped
+    /// literals), freed by deinit.
+    owned_paths: std.ArrayListUnmanaged([]const u8) = .empty,
 
     pub fn deinit(self: *Analysis, allocator: std.mem.Allocator) void {
+        for (self.owned_paths.items) |p| allocator.free(p);
+        self.owned_paths.deinit(allocator);
         self.imports.deinit(allocator);
         self.aliases.deinit(allocator);
         self.calls.deinit(allocator);
@@ -103,7 +108,8 @@ const Found = struct {
 };
 
 /// `source` must be sentinel-terminated; returned `Import.path` slices point
-/// into it, so it must outlive the analysis.
+/// into it (or into `Analysis.owned_paths` for escaped literals), so both
+/// must outlive the analysis.
 pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
     var tree = try std.zig.Ast.parse(allocator, source, .zig);
     defer tree.deinit(allocator);
@@ -118,7 +124,7 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
             .aligned_var_decl => tree.alignedVarDecl(node),
             else => null,
         };
-        const found = if (vd) |decl| classifyDecl(tree, source, node, decl) else null;
+        const found = if (vd) |decl| try classifyDecl(allocator, &result.owned_paths, tree, source, node, decl) else null;
         if (found) |f| {
             if (f.alias) {
                 try result.aliases.append(allocator, f.imp);
@@ -130,7 +136,7 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
 
     result.block_end = lineBlockEnd(source, result.imports.items, result.aliases.items);
 
-    result.calls = try importCalls(allocator, tree);
+    result.calls = try importCalls(allocator, &result.owned_paths, tree);
     result.allowed = try collectAllowedOffsets(allocator, tree);
 
     // Aliases outside the block are left alone (never hoisted).
@@ -227,7 +233,7 @@ pub const ImportCall = struct {
     path: ?[]const u8,
 };
 
-pub fn importCalls(allocator: std.mem.Allocator, tree: Ast) !std.ArrayListUnmanaged(ImportCall) {
+pub fn importCalls(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]const u8), tree: Ast) !std.ArrayListUnmanaged(ImportCall) {
     var calls: std.ArrayListUnmanaged(ImportCall) = .empty;
     errdefer calls.deinit(allocator);
 
@@ -242,13 +248,13 @@ pub fn importCalls(allocator: std.mem.Allocator, tree: Ast) !std.ArrayListUnmana
         const arg = builtinArg(tree, node);
         try calls.append(allocator, .{
             .offset = tree.tokens.items(.start)[tree.firstToken(node)],
-            .path = if (arg) |a| stringPath(tree, a) else null,
+            .path = if (arg) |a| try stringPath(allocator, owned, tree, a) else null,
         });
     }
     return calls;
 }
 
-fn classifyDecl(tree: Ast, source: []const u8, node: Ast.Node.Index, vd: Ast.full.VarDecl) ?Found {
+fn classifyDecl(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]const u8), tree: Ast, source: []const u8, node: Ast.Node.Index, vd: Ast.full.VarDecl) !?Found {
     if (!std.mem.eql(u8, tree.tokenSlice(vd.ast.mut_token), "const")) return null;
     const init = vd.ast.init_node.unwrap() orelse return null;
     const init_slice = tree.tokenSlice(tree.firstToken(init));
@@ -260,7 +266,7 @@ fn classifyDecl(tree: Ast, source: []const u8, node: Ast.Node.Index, vd: Ast.ful
             .{ "<cimport>", class_third_party }
         else blk: {
             const arg = builtinArg(tree, init) orelse return null;
-            const p = stringPath(tree, arg) orelse return null;
+            const p = (try stringPath(allocator, owned, tree, arg)) orelse return null;
             break :blk .{ p, classify(p) };
         };
         return .{ .imp = .{
@@ -299,11 +305,19 @@ fn builtinArg(tree: Ast, call: Ast.Node.Index) ?Ast.Node.Index {
     return args[0].unwrap();
 }
 
-fn stringPath(tree: Ast, arg: Ast.Node.Index) ?[]const u8 {
+/// Path of a string-literal argument: the raw token body when it contains no
+/// escapes, otherwise the decoded contents stored in `owned`. Returns null
+/// for non-string or invalid (multiline) literals.
+fn stringPath(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]const u8), tree: Ast, arg: Ast.Node.Index) !?[]const u8 {
     if (tree.nodeTag(arg) != .string_literal) return null;
     const lit = tree.tokenSlice(tree.firstToken(arg));
     if (lit.len < 2) return null;
-    return lit[1 .. lit.len - 1];
+    const body = lit[1 .. lit.len - 1];
+    if (std.mem.indexOfScalar(u8, body, '\\') == null) return body;
+    if (lit[0] != '"' or lit[lit.len - 1] != '"') return null;
+    const decoded = std.zig.string_literal.parseAlloc(allocator, lit) catch return null;
+    try owned.append(allocator, decoded);
+    return decoded;
 }
 
 /// Single-line, whitespace-free dotted chain starting with an identifier:
@@ -327,20 +341,15 @@ fn declStart(tree: Ast, node: Ast.Node.Index) usize {
     return tree.tokens.items(.start)[tree.firstToken(node)];
 }
 
-/// End of an import/alias span: decl nodes exclude the trailing `;`, so
-/// extend to the next `;` token, then to the end of that line so trailing
-/// inline comments travel with the import.
+/// End of an import/alias span: the `;` immediately following the decl's
+/// last token (decl nodes exclude it), then to the end of that line so
+/// trailing inline comments travel with the import. A missing `;` ends the
+/// span at the last token's line instead of crossing into a later decl.
 fn spanEnd(tree: Ast, source: []const u8, node: Ast.Node.Index) usize {
-    const eof_idx = tree.tokens.len - 1;
     const last_node_token = tree.lastToken(node);
-    var t: u32 = last_node_token;
-    while (t < eof_idx) : (t += 1) {
-        if (tree.tokens.items(.tag)[t] == .semicolon) {
-            return findLineEnd(source, tree.tokens.items(.start)[t]);
-        }
-        // Do not cross into a later declaration.
-        if (t > last_node_token and !tree.tokensOnSameLine(last_node_token, t)) break;
+    const next = last_node_token + 1;
+    if (next < tree.tokens.len and tree.tokens.items(.tag)[next] == .semicolon) {
+        return findLineEnd(source, tree.tokens.items(.start)[next]);
     }
-    const last = if (t > 0) t - 1 else 0;
-    return findLineEnd(source, tree.tokens.items(.start)[last] + @as(u32, @intCast(tree.tokenSlice(last).len)));
+    return findLineEnd(source, tree.tokens.items(.start)[last_node_token] + @as(u32, @intCast(tree.tokenSlice(last_node_token).len)));
 }

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -23,6 +23,13 @@ pub fn readFileAlloc(io: Io, dir: Dir, path: []const u8, allocator: std.mem.Allo
     return dir.readFileAlloc(allocator, path, max);
 }
 
+/// Sentinel-terminated read for `std.zig.Ast.parse`, which requires
+/// `[:0]const u8`. Both 0.15 and 0.16 accept a sentinel in the options form.
+pub fn readFileAllocZ(io: Io, dir: Dir, path: []const u8, allocator: std.mem.Allocator, max: usize) ![:0]u8 {
+    if (is_v016) return std.Io.Dir.readFileAllocOptions(dir, io, path, allocator, .limited(max), .of(u8), 0);
+    return dir.readFileAllocOptions(allocator, path, max, null, .of(u8), 0);
+}
+
 pub fn statFile(io: Io, dir: Dir, path: []const u8) !Stat {
     if (is_v016) return std.Io.Dir.statFile(dir, io, path, .{});
     return dir.statFile(path);

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -2,331 +2,41 @@
 
 const std = @import("std");
 
+const ast_scan = @import("ast_scan.zig");
 const compat = @import("compat.zig");
 
 pub const version = "0.1.0";
 
-pub const class_std_builtin: u2 = 0;
-pub const class_third_party: u2 = 1;
-pub const class_local: u2 = 2;
+pub const class_std_builtin = ast_scan.class_std_builtin;
+pub const class_third_party = ast_scan.class_third_party;
+pub const class_local = ast_scan.class_local;
+pub const Import = ast_scan.Import;
+pub const classify = ast_scan.classify;
+pub const analyze = ast_scan.analyze;
 
-pub const Import = struct {
-    start: usize,
-    end: usize,
-    path: []const u8,
-    class: u2,
-    stray: bool = false,
-    comment_start: ?usize = null,
-
-    fn lessThan(ctx: void, a: Import, b: Import) bool {
-        _ = ctx;
-        if (a.class != b.class) return a.class < b.class;
-        const cmp = std.mem.order(u8, a.path, b.path);
-        if (cmp != .eq) return cmp == .lt;
-        const a_len = a.end - a.start;
-        const b_len = b.end - b.start;
-        if (a_len != b_len) return a_len < b_len;
-        return a.start < b.start;
-    }
-};
-
-pub fn classify(path: []const u8) u2 {
-    if (std.mem.eql(u8, path, "std") or std.mem.eql(u8, path, "builtin")) {
-        return class_std_builtin;
-    }
-    if (std.mem.eql(u8, path, "root") or std.mem.eql(u8, path, "build_root") or
-        std.mem.indexOfScalar(u8, path, '/') != null or
-        std.mem.endsWith(u8, path, ".zig"))
-    {
-        return class_local;
-    }
-    return class_third_party;
-}
-
-fn skipStringOrComment(source: []const u8, pos: usize) usize {
-    const ch = source[pos];
-    if (ch == '"' or ch == '\'') {
-        var i = pos + 1;
-        while (i < source.len and source[i] != ch) : (i += 1) {
-            if (source[i] == '\\') i += 1;
-        }
-        return @min(i + 1, source.len);
-    }
-    if (ch == '/' and pos + 1 < source.len) {
-        if (source[pos + 1] == '/') {
-            var i = pos + 2;
-            while (i < source.len and source[i] != '\n') : (i += 1) {}
-            return @min(i + 1, source.len);
-        }
-    }
-    if (ch == '\\' and pos + 1 < source.len and source[pos + 1] == '\\') {
-        var k = pos;
-        while (k > 0 and source[k - 1] != '\n') : (k -= 1) {
-            if (source[k - 1] != ' ' and source[k - 1] != '\t') break;
-        }
-        if (k == 0 or source[k - 1] == '\n') {
-            var i = pos + 2;
-            while (i < source.len and source[i] != '\n') : (i += 1) {}
-            return @min(i + 1, source.len);
-        }
-    }
-    return pos;
-}
-
-fn findLineStart(source: []const u8, pos: usize) usize {
-    var i = pos;
-    while (i > 0) : (i -= 1) {
-        if (source[i - 1] == '\n') return i;
-    }
-    return 0;
-}
-
-fn findLineEnd(source: []const u8, pos: usize) usize {
-    var i = pos;
-    while (i < source.len) : (i += 1) {
-        if (source[i] == '\n') return i + 1;
-    }
-    return source.len;
-}
-
-fn findCommentStart(source: []const u8, line_start: usize) ?usize {
-    if (line_start == 0) return null;
-    var comment_start: ?usize = null;
-    var back = line_start - 1;
-    while (true) {
-        const prev_start = findLineStart(source, back);
-        const prev_end = findLineEnd(source, prev_start);
-        const prev_trimmed = std.mem.trimStart(u8, source[prev_start..prev_end], " \t\r");
-        if (prev_trimmed.len == 0 or std.mem.startsWith(u8, prev_trimmed, "//")) {
-            comment_start = prev_start;
-            if (prev_start == 0) return null;
-            back = prev_start - 1;
-        } else {
-            break;
-        }
-    }
-    return comment_start;
-}
-
-pub fn findCImportEnd(source: []const u8, pos: usize) usize {
-    var i = pos;
-    var depth: usize = 0;
-    var started = false;
-    while (i < source.len) {
-        const skip = skipStringOrComment(source, i);
-        if (skip != i) {
-            i = skip;
-            continue;
-        }
-        if (source[i] == '{') {
-            started = true;
-            depth += 1;
-        } else if (source[i] == '}') {
-            if (!started) break;
-            depth -= 1;
-            if (depth == 0) {
-                while (i + 1 < source.len and source[i + 1] != '\n') : (i += 1) {}
-                if (i + 1 < source.len and source[i + 1] == '\n') i += 1;
-                return i + 1;
-            }
-        }
-        i += 1;
-    }
-    return findLineEnd(source, pos);
-}
-
-pub fn extractPath(source: []const u8, needle: []const u8) ?[]const u8 {
-    const pos = std.mem.indexOf(u8, source, needle) orelse return null;
-    var open = pos + needle.len;
-    while (open < source.len and
-        (source[open] == ' ' or source[open] == '\t' or source[open] == '\r' or source[open] == '\n')) : (open += 1)
-    {}
-    if (open >= source.len) return null;
-    const close = std.mem.indexOfScalar(u8, source[open..], ')') orelse return null;
-    const inner = source[open .. open + close];
-    if (inner.len == 0) return null;
-    if (inner[0] == '"') {
-        const e = std.mem.indexOfScalar(u8, inner[1..], '"') orelse return null;
-        return inner[1 .. 1 + e];
-    }
-    return null;
-}
-
-fn endsWithSemicolon(trimmed: []const u8) bool {
-    var t = trimmed;
-    if (std.mem.indexOf(u8, t, "//")) |c| t = t[0..c];
-    t = std.mem.trimEnd(u8, t, " \t\r\n");
-    return t.len > 0 and t[t.len - 1] == ';';
-}
-
-// only the first token after = is a type keyword; trailing comment/string text must not count
-fn hasTypeKeyword(trimmed: []const u8, keyword: []const u8) bool {
-    const eq = std.mem.indexOfScalar(u8, trimmed, '=') orelse return false;
-    const rhs = std.mem.trimStart(u8, trimmed[eq + 1 ..], " \t");
-    if (!std.mem.startsWith(u8, rhs, keyword)) return false;
-    const after = keyword.len;
-    return after >= rhs.len or
-        (!std.ascii.isAlphanumeric(rhs[after]) and rhs[after] != '_');
-}
-
-pub fn isTopLevelImportLine(line: []const u8) bool {
-    const trimmed = std.mem.trimStart(u8, line, " \t\n\r");
-    if (trimmed.len == 0) return true;
-    if (std.mem.startsWith(u8, trimmed, "//")) return true;
-
-    if (std.mem.startsWith(u8, trimmed, "const ") or
-        std.mem.startsWith(u8, trimmed, "pub const "))
-    {
-        if (hasTypeKeyword(trimmed, "struct")) return false;
-        if (hasTypeKeyword(trimmed, "enum")) return false;
-        if (hasTypeKeyword(trimmed, "union")) return false;
-        if (hasTypeKeyword(trimmed, "opaque")) return false;
-
-        if (std.mem.indexOf(u8, trimmed, "@import") != null) return endsWithSemicolon(trimmed);
-        if (std.mem.indexOf(u8, trimmed, "@cImport") != null) return endsWithSemicolon(trimmed);
-
-        const eq = std.mem.indexOfScalar(u8, trimmed, '=') orelse return false;
-        const before_eq = trimmed[0..eq];
-        if (std.mem.indexOfScalar(u8, before_eq, ':') != null) return false;
-        const rhs = std.mem.trim(u8, trimmed[eq + 1 ..], " \t;\n\r");
-        if (rhs.len == 0 or (!std.ascii.isAlphabetic(rhs[0]) and rhs[0] != '_')) return false;
-        var has_dot = false;
-        for (rhs) |c| {
-            if (!std.ascii.isAlphanumeric(c) and c != '.' and c != '_') return false;
-            if (c == '.') has_dot = true;
-        }
-        if (!has_dot) return false;
-        return endsWithSemicolon(trimmed);
-    }
-
-    if (std.mem.startsWith(u8, trimmed, "_ = @import")) return endsWithSemicolon(trimmed);
-
-    return false;
-}
+const findLineStart = ast_scan.findLineStart;
+const findLineEnd = ast_scan.findLineEnd;
 
 pub fn collectImports(
     allocator: std.mem.Allocator,
-    source: []const u8,
+    source: [:0]const u8,
     block_end: usize,
 ) !std.ArrayListUnmanaged(Import) {
-    var imports: std.ArrayListUnmanaged(Import) = .empty;
-    errdefer imports.deinit(allocator);
-
-    var i: usize = 0;
-    var depth: usize = 0;
-
-    while (i < source.len) {
-        const skip = skipStringOrComment(source, i);
-        if (skip != i) {
-            i = skip;
-            continue;
-        }
-        if (source[i] == '{') {
-            depth += 1;
-            i += 1;
-            continue;
-        }
-        if (source[i] == '}') {
-            depth -|= 1;
-            i += 1;
-            continue;
-        }
-
-        if (std.mem.startsWith(u8, source[i..], "@import(")) {
-            if (depth > 0) {
-                i += "@import(".len;
-                continue;
-            }
-            const found = i;
-            const line_start = findLineStart(source, found);
-            const line_end = findLineEnd(source, found);
-            const line = std.mem.trimStart(u8, source[line_start..line_end], " \t\r");
-            if (!std.mem.startsWith(u8, line, "const ") and
-                !std.mem.startsWith(u8, line, "pub const ") and
-                !std.mem.startsWith(u8, line, "_ = @import"))
-            {
-                i = line_end;
-                continue;
-            }
-            const path = extractPath(source[found..], "@import(") orelse {
-                i = line_end;
-                continue;
-            };
-            const comment_start = findCommentStart(source, line_start);
-            var import_end = line_end;
-            if (!endsWithSemicolon(line)) {
-                var j = line_end;
-                while (j < source.len) {
-                    const j_skip = skipStringOrComment(source, j);
-                    if (j_skip != j) {
-                        j = j_skip;
-                        continue;
-                    }
-                    if (source[j] == ';') {
-                        import_end = j + 1;
-                        break;
-                    }
-                    if (source[j] == '{' or source[j] == '}') break;
-                    j += 1;
-                }
-                if (import_end == line_end) {
-                    i = line_end;
-                    continue;
-                }
-            }
-            try imports.append(allocator, .{
-                .start = line_start,
-                .end = import_end,
-                .path = path,
-                .class = classify(path),
-                .stray = found >= block_end,
-                .comment_start = comment_start,
-            });
-            i = import_end;
-            continue;
-        }
-
-        if (std.mem.startsWith(u8, source[i..], "@cImport(")) {
-            if (depth > 0) {
-                i += "@cImport(".len;
-                continue;
-            }
-            const found = i;
-            const line_start = findLineStart(source, found);
-            const block_end_cimport = findCImportEnd(source, found);
-            const comment_start = findCommentStart(source, line_start);
-            try imports.append(allocator, .{
-                .start = line_start,
-                .end = block_end_cimport,
-                .path = "<cimport>",
-                .class = class_third_party,
-                .stray = found >= block_end,
-                .comment_start = comment_start,
-            });
-            i = block_end_cimport;
-            continue;
-        }
-
-        i += 1;
-    }
-
-    std.sort.pdq(Import, imports.items, {}, Import.lessThan);
-    return imports;
+    var analysis = try ast_scan.analyze(allocator, source);
+    defer analysis.deinit(allocator);
+    var result: std.ArrayListUnmanaged(Import) = .empty;
+    errdefer result.deinit(allocator);
+    try result.appendSlice(allocator, analysis.imports.items);
+    for (result.items) |*imp| imp.stray = imp.start >= block_end;
+    return result;
 }
 
 pub fn findImportBlockEnd(source: []const u8) usize {
-    var pos: usize = 0;
-    while (pos < source.len) {
-        const line_end = findLineEnd(source, pos);
-        const line = source[pos..line_end];
-        if (std.mem.indexOf(u8, line, "@cImport(")) |cimport_pos| {
-            pos = findCImportEnd(source, pos + cimport_pos);
-            continue;
-        }
-        if (!isTopLevelImportLine(line)) return pos;
-        pos = line_end;
-    }
-    return pos;
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const dup = arena.allocator().dupeZ(u8, source) catch return source.len;
+    const analysis = ast_scan.analyze(arena.allocator(), dup) catch return source.len;
+    return analysis.block_end;
 }
 
 fn allocFmt(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ?[]const u8 {
@@ -341,38 +51,31 @@ pub fn hasBannedPatterns(
     source: []const u8,
     banned_prefixes: []const []const u8,
 ) !?[]const u8 {
-    var i: usize = 0;
-    while (i < source.len) {
-        const skip = skipStringOrComment(source, i);
-        if (skip != i) {
-            i = skip;
-            continue;
+    const dup = try allocator.dupeZ(u8, source);
+    defer allocator.free(dup);
+    var tree = try std.zig.Ast.parse(allocator, dup, .zig);
+    defer tree.deinit(allocator);
+    var calls = try ast_scan.importCalls(allocator, tree);
+    defer calls.deinit(allocator);
+
+    for (calls.items) |call| {
+        const line_start = findLineStart(source, call.offset);
+        const line_end_excl = findLineEnd(source, call.offset);
+        const line = std.mem.trimStart(u8, source[line_start..line_end_excl], " \t\r");
+
+        if (!std.mem.startsWith(u8, line, "const ") and
+            !std.mem.startsWith(u8, line, "pub const "))
+        {
+            return allocFmt(allocator, "inline @import in type expression", .{}) orelse return error.OutOfMemory;
         }
-        if (std.mem.startsWith(u8, source[i..], "@import(")) {
-            const found = i;
-            const line_start = findLineStart(source, found);
-            const line_end_excl = findLineEnd(source, found);
-            const line = std.mem.trimStart(u8, source[line_start..line_end_excl], " \t\r");
 
-            if (!std.mem.startsWith(u8, line, "const ") and
-                !std.mem.startsWith(u8, line, "pub const ") and
-                !std.mem.startsWith(u8, line, "_ = @import"))
-            {
-                return allocFmt(allocator, "inline @import in type expression", .{}) orelse return error.OutOfMemory;
-            }
-
-            if (extractPath(source[found..], "@import(")) |path| {
-                for (banned_prefixes) |prefix| {
-                    if (std.mem.startsWith(u8, path, prefix)) {
-                        return allocFmt(allocator, "import path starts with banned prefix '{s}'", .{prefix}) orelse return error.OutOfMemory;
-                    }
+        if (call.path) |path| {
+            for (banned_prefixes) |prefix| {
+                if (std.mem.startsWith(u8, path, prefix)) {
+                    return allocFmt(allocator, "import path starts with banned prefix '{s}'", .{prefix}) orelse return error.OutOfMemory;
                 }
             }
-
-            i = line_end_excl;
-            continue;
         }
-        i += 1;
     }
 
     return null;
@@ -395,11 +98,9 @@ pub fn buildSortedImportText(
     allocator: std.mem.Allocator,
     source: []const u8,
     sorted_imports: []const Import,
+    aliases: []const Import,
     block_end: usize,
 ) ![]const u8 {
-    var extra_imports: std.ArrayListUnmanaged(Import) = .empty;
-    defer extra_imports.deinit(allocator);
-
     var preamble_lines: std.ArrayListUnmanaged([]const u8) = .empty;
     defer preamble_lines.deinit(allocator);
 
@@ -425,69 +126,15 @@ pub fn buildSortedImportText(
             continue;
         }
         seen_content = true;
-        if (std.mem.startsWith(u8, trimmed, "const ") or std.mem.startsWith(u8, trimmed, "pub const ")) {
-            if (std.mem.indexOf(u8, trimmed, "@import(") == null and
-                std.mem.indexOf(u8, trimmed, "@cImport(") == null)
-            {
-                const eq = std.mem.indexOfScalar(u8, trimmed, '=') orelse {
-                    pos = le;
-                    trailing_comment_start = null;
-                    trailing_comments.clearRetainingCapacity();
-                    continue;
-                };
-                const rhs_raw = trimmed[eq + 1 ..];
-                const rhs = std.mem.trim(u8, rhs_raw, " \t;\n\r");
-                if (rhs.len == 0 or (!std.ascii.isAlphabetic(rhs[0]) and rhs[0] != '_')) {
-                    pos = le;
-                    trailing_comment_start = null;
-                    trailing_comments.clearRetainingCapacity();
-                    continue;
-                }
-                var valid_rhs = true;
-                for (rhs) |c| {
-                    if (!std.ascii.isAlphanumeric(c) and c != '.' and c != '_') {
-                        valid_rhs = false;
-                        break;
-                    }
-                }
-                if (!valid_rhs) {
-                    pos = le;
-                    trailing_comment_start = null;
-                    trailing_comments.clearRetainingCapacity();
-                    continue;
-                }
-                const dot = std.mem.indexOfScalar(u8, rhs, '.') orelse {
-                    pos = le;
-                    trailing_comment_start = null;
-                    trailing_comments.clearRetainingCapacity();
-                    continue;
-                };
-                const module_name = rhs[0..dot];
-                const attached_comment_start = trailing_comment_start;
-                trailing_comment_start = null;
-                trailing_comments.clearRetainingCapacity();
-                try extra_imports.append(allocator, .{
-                    .start = pos,
-                    .end = le,
-                    .path = rhs,
-                    .class = classify(module_name),
-                    .stray = false,
-                    .comment_start = attached_comment_start,
-                });
-            } else {
-                trailing_comment_start = null;
-                trailing_comments.clearRetainingCapacity();
-            }
-        } else {
-            trailing_comment_start = null;
-            trailing_comments.clearRetainingCapacity();
-        }
+        trailing_comment_start = null;
+        trailing_comments.clearRetainingCapacity();
         pos = le;
     }
 
     var all_imports: std.ArrayListUnmanaged(Import) = .empty;
     defer all_imports.deinit(allocator);
     try all_imports.appendSlice(allocator, sorted_imports);
+    try all_imports.appendSlice(allocator, aliases);
 
     var imports_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer imports_buf.deinit(allocator);
@@ -495,8 +142,10 @@ pub fn buildSortedImportText(
     const nl = detectNewline(source);
 
     var prev_class: ?u2 = null;
-    for (all_imports.items) |imp| {
-        if (prev_class != null and prev_class.? != imp.class) {
+    for (all_imports.items, 0..) |imp, idx| {
+        if (idx == sorted_imports.len and sorted_imports.len > 0) {
+            try imports_buf.appendSlice(allocator, nl);
+        } else if (prev_class != null and prev_class.? != imp.class) {
             try imports_buf.appendSlice(allocator, nl);
         }
         prev_class = imp.class;
@@ -508,26 +157,6 @@ pub fn buildSortedImportText(
         if (trimmed_import.len > 0) {
             try imports_buf.appendSlice(allocator, trimmed_import);
             try imports_buf.appendSlice(allocator, nl);
-        }
-    }
-
-    if (extra_imports.items.len > 0) {
-        if (imports_buf.items.len > 0 and imports_buf.items[imports_buf.items.len - 1] != '\n') {
-            try imports_buf.appendSlice(allocator, nl);
-        }
-        if (all_imports.items.len > 0) {
-            try imports_buf.appendSlice(allocator, nl);
-        }
-        for (extra_imports.items) |imp| {
-            if (imp.comment_start) |cs| {
-                try imports_buf.appendSlice(allocator, source[cs..imp.start]);
-            }
-            const text = source[imp.start..imp.end];
-            const trimmed_import = std.mem.trim(u8, text, " \t\n\r");
-            if (trimmed_import.len > 0) {
-                try imports_buf.appendSlice(allocator, trimmed_import);
-                try imports_buf.appendSlice(allocator, nl);
-            }
         }
     }
 
@@ -804,14 +433,24 @@ pub fn processSource(
         };
     }
 
-    const block_end = findImportBlockEnd(source);
-    var imports = try collectImports(allocator, source, block_end);
-    defer imports.deinit(allocator);
+    const dup = allocator.dupeZ(u8, source) catch return error.OutOfMemory;
+    var analysis = ast_scan.analyze(allocator, dup) catch |e| {
+        allocator.free(dup);
+        return e;
+    };
+    // Import paths slice into `dup`, but are only read inside analyze
+    // (sorting/classifying); everything downstream uses start/end/class.
+    allocator.free(dup);
+    defer analysis.deinit(allocator);
+
+    const block_end = analysis.block_end;
+    const imports = analysis.imports.items;
+    const aliases = analysis.aliases.items;
 
     const banned_msg = try hasBannedPatterns(allocator, source, banned_prefixes);
     errdefer if (banned_msg) |msg| allocator.free(msg);
 
-    if (imports.items.len == 0) {
+    if (imports.len == 0) {
         return .{
             .new_text = source,
             .new_block = source,
@@ -825,7 +464,7 @@ pub fn processSource(
 
     var stray_imports = std.ArrayListUnmanaged(Import).empty;
     defer stray_imports.deinit(allocator);
-    for (imports.items) |imp| {
+    for (imports) |imp| {
         if (imp.stray) {
             try stray_imports.append(allocator, imp);
         }
@@ -856,7 +495,7 @@ pub fn processSource(
         rest = owned;
     }
 
-    const new_imports = try buildSortedImportText(allocator, source, imports.items, block_end);
+    const new_imports = try buildSortedImportText(allocator, source, imports, aliases, block_end);
     errdefer allocator.free(new_imports);
 
     const original_block = source[0..block_end];
@@ -1015,7 +654,7 @@ const FileJob = struct {
 
 fn processFileJob(job: *const FileJob, io: compat.Io) void {
     const allocator = job.slot.arena.allocator();
-    const source = compat.readFileAlloc(io, compat.cwd(), job.path, allocator, 10 * 1024 * 1024) catch |err| {
+    const source = compat.readFileAllocZ(io, compat.cwd(), job.path, allocator, 10 * 1024 * 1024) catch |err| {
         job.slot.read_err = @errorName(err);
         return;
     };

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -14,36 +14,33 @@ pub const Import = ast_scan.Import;
 pub const classify = ast_scan.classify;
 pub const analyze = ast_scan.analyze;
 
-const findLineStart = ast_scan.findLineStart;
 const findLineEnd = ast_scan.findLineEnd;
-
-pub fn collectImports(
-    allocator: std.mem.Allocator,
-    source: [:0]const u8,
-    block_end: usize,
-) !std.ArrayListUnmanaged(Import) {
-    var analysis = try ast_scan.analyze(allocator, source);
-    defer analysis.deinit(allocator);
-    var result: std.ArrayListUnmanaged(Import) = .empty;
-    errdefer result.deinit(allocator);
-    try result.appendSlice(allocator, analysis.imports.items);
-    for (result.items) |*imp| imp.stray = imp.start >= block_end;
-    return result;
-}
-
-pub fn findImportBlockEnd(source: []const u8) usize {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const dup = arena.allocator().dupeZ(u8, source) catch return source.len;
-    const analysis = ast_scan.analyze(arena.allocator(), dup) catch return source.len;
-    return analysis.block_end;
-}
 
 fn allocFmt(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ?[]const u8 {
     return std.fmt.allocPrint(allocator, fmt, args) catch |err| {
         std.debug.print("zsort: failed to format message: {s}\n", .{@errorName(err)});
         return null;
     };
+}
+
+fn scanBannedPatterns(
+    allocator: std.mem.Allocator,
+    analysis: *const ast_scan.Analysis,
+    banned_prefixes: []const []const u8,
+) !?[]const u8 {
+    for (analysis.calls.items) |call| {
+        if (std.mem.indexOfScalar(usize, analysis.allowed.items, call.offset) == null) {
+            return allocFmt(allocator, "inline @import in type expression", .{}) orelse return error.OutOfMemory;
+        }
+        if (call.path) |path| {
+            for (banned_prefixes) |prefix| {
+                if (std.mem.startsWith(u8, path, prefix)) {
+                    return allocFmt(allocator, "import path starts with banned prefix '{s}'", .{prefix}) orelse return error.OutOfMemory;
+                }
+            }
+        }
+    }
+    return null;
 }
 
 pub fn hasBannedPatterns(
@@ -53,32 +50,9 @@ pub fn hasBannedPatterns(
 ) !?[]const u8 {
     const dup = try allocator.dupeZ(u8, source);
     defer allocator.free(dup);
-    var tree = try std.zig.Ast.parse(allocator, dup, .zig);
-    defer tree.deinit(allocator);
-    var calls = try ast_scan.importCalls(allocator, tree);
-    defer calls.deinit(allocator);
-
-    for (calls.items) |call| {
-        const line_start = findLineStart(source, call.offset);
-        const line_end_excl = findLineEnd(source, call.offset);
-        const line = std.mem.trimStart(u8, source[line_start..line_end_excl], " \t\r");
-
-        if (!std.mem.startsWith(u8, line, "const ") and
-            !std.mem.startsWith(u8, line, "pub const "))
-        {
-            return allocFmt(allocator, "inline @import in type expression", .{}) orelse return error.OutOfMemory;
-        }
-
-        if (call.path) |path| {
-            for (banned_prefixes) |prefix| {
-                if (std.mem.startsWith(u8, path, prefix)) {
-                    return allocFmt(allocator, "import path starts with banned prefix '{s}'", .{prefix}) orelse return error.OutOfMemory;
-                }
-            }
-        }
-    }
-
-    return null;
+    var analysis = try ast_scan.analyze(allocator, dup);
+    defer analysis.deinit(allocator);
+    return scanBannedPatterns(allocator, &analysis, banned_prefixes);
 }
 
 fn detectNewline(source: []const u8) []const u8 {
@@ -145,7 +119,7 @@ pub fn buildSortedImportText(
     for (all_imports.items, 0..) |imp, idx| {
         if (idx == sorted_imports.len and sorted_imports.len > 0) {
             try imports_buf.appendSlice(allocator, nl);
-        } else if (prev_class != null and prev_class.? != imp.class) {
+        } else if (idx < sorted_imports.len and prev_class != null and prev_class.? != imp.class) {
             try imports_buf.appendSlice(allocator, nl);
         }
         prev_class = imp.class;
@@ -418,7 +392,7 @@ pub const ProcessResult = struct {
 
 pub fn processSource(
     allocator: std.mem.Allocator,
-    source: []const u8,
+    source: [:0]const u8,
     banned_prefixes: []const []const u8,
 ) !ProcessResult {
     if (hasSkipComment(source)) {
@@ -433,21 +407,14 @@ pub fn processSource(
         };
     }
 
-    const dup = allocator.dupeZ(u8, source) catch return error.OutOfMemory;
-    var analysis = ast_scan.analyze(allocator, dup) catch |e| {
-        allocator.free(dup);
-        return e;
-    };
-    // Import paths slice into `dup`, but are only read inside analyze
-    // (sorting/classifying); everything downstream uses start/end/class.
-    allocator.free(dup);
+    var analysis = try ast_scan.analyze(allocator, source);
     defer analysis.deinit(allocator);
 
     const block_end = analysis.block_end;
     const imports = analysis.imports.items;
     const aliases = analysis.aliases.items;
 
-    const banned_msg = try hasBannedPatterns(allocator, source, banned_prefixes);
+    const banned_msg = try scanBannedPatterns(allocator, &analysis, banned_prefixes);
     errdefer if (banned_msg) |msg| allocator.free(msg);
 
     if (imports.len == 0) {
@@ -470,7 +437,7 @@ pub fn processSource(
         }
     }
 
-    var rest = source[block_end..];
+    var rest: []const u8 = source[block_end..];
     var rest_owned: ?[]const u8 = null;
     errdefer if (rest_owned) |owned| allocator.free(owned);
     if (stray_imports.items.len > 0) {

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -333,6 +333,13 @@ test "hasBannedPatterns: whitespace after @import( still detected" {
     try std.testing.expect(std.mem.indexOf(u8, msg, "./") != null);
 }
 
+test "hasBannedPatterns: escaped path decoded before prefix check" {
+    const source = "const foo = @import(\"\\x2e/bar\");\n";
+    const msg = try zsort.hasBannedPatterns(std.testing.allocator, source, &.{"./"}) orelse return error.TestFailed;
+    defer std.testing.allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "./") != null);
+}
+
 test "processSource: collapses consecutive CRLF blank lines" {
     const source = "// h\r\n\r\n\r\nconst bar = @import(\"bar\");\r\n\r\npub fn main() {}\r\n";
     const result = try zsort.processSource(std.testing.allocator, source, &.{});
@@ -591,6 +598,27 @@ test "buildSortedImportText: comment travels with its import" {
     try std.testing.expect(std_pos < bar_pos);
 }
 
+test "buildSortedImportText: blank-line-separated comment travels with its import" {
+    const source =
+        \\const bar = @import("bar");
+        \\// std comment
+        \\
+        \\const std = @import("std");
+        \\
+        \\const rest = 1;
+    ;
+    const block_end = blockEndForTest(source);
+    var imports = try collectImportsForTest(source, block_end);
+    defer imports.deinit(std.testing.allocator);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    defer std.testing.allocator.free(result);
+    const std_pos = std.mem.indexOf(u8, result, "const std") orelse return error.TestUnexpectedResult;
+    const comment_pos = std.mem.indexOf(u8, result, "// std comment") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(comment_pos < std_pos);
+}
+
 test "buildSortedImportText: alias imports hoisted after imports" {
     const source =
         \\const bar = @import("bar");
@@ -637,6 +665,24 @@ test "analyze: typed import is collected" {
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.imports.items.len);
     try std.testing.expectEqualStrings("a", analysis.imports.items[0].path);
+}
+
+test "analyze: escaped import path is decoded" {
+    const source = "const foo = @import(\"\\x2ffoo.zig\");\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), analysis.imports.items.len);
+    try std.testing.expectEqualStrings("/foo.zig", analysis.imports.items[0].path);
+    try std.testing.expectEqual(zsort.class_local, analysis.imports.items[0].class);
+}
+
+test "analyze: escaped paths sort by decoded text" {
+    const source = "const first = @import(\"\\x7a\");\nconst second = @import(\"\\x61\");\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), analysis.imports.items.len);
+    try std.testing.expectEqualStrings("a", analysis.imports.items[0].path);
+    try std.testing.expectEqualStrings("z", analysis.imports.items[1].path);
 }
 
 test "analyze: var import is not collected" {

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -30,7 +30,7 @@ test "findImportBlockEnd: ends at first non-import" {
         \\
         \\const Foo = struct {
     ;
-    try std.testing.expectEqual("const std = @import(\"std\");\n\n".len, zsort.findImportBlockEnd(source));
+    try std.testing.expectEqual("const std = @import(\"std\");\n\n".len, blockEndForTest(source));
 }
 
 test "findImportBlockEnd: alias to struct-like module does not end block" {
@@ -41,7 +41,7 @@ test "findImportBlockEnd: alias to struct-like module does not end block" {
     ;
     try std.testing.expectEqual(
         "const std = @import(\"std\");\nconst Enum = enums.Kind;\nconst Other = @import(\"other\");".len,
-        zsort.findImportBlockEnd(source),
+        blockEndForTest(source),
     );
 }
 
@@ -103,7 +103,7 @@ test "buildSortedImportText: basic sort" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
@@ -126,7 +126,7 @@ test "buildSortedImportText: idempotent fix twice" {
         \\
         \\pub fn main() !void {}
     ;
-    const block_end1 = zsort.findImportBlockEnd(source);
+    const block_end1 = blockEndForTest(source);
     var imports1 = try collectImportsForTest(source, block_end1);
     defer imports1.deinit(std.testing.allocator);
     var aliases1 = try collectAliasesForTest(source);
@@ -141,7 +141,7 @@ test "buildSortedImportText: idempotent fix twice" {
 
     const full1_z = try std.testing.allocator.dupeZ(u8, full1.items);
     defer std.testing.allocator.free(full1_z);
-    const block_end2 = zsort.findImportBlockEnd(full1_z);
+    const block_end2 = blockEndForTest(full1_z);
     var imports2 = try collectImportsForTest(full1_z, block_end2);
     defer imports2.deinit(std.testing.allocator);
     var aliases2 = try collectAliasesForTest(full1_z);
@@ -161,7 +161,7 @@ test "buildSortedImportText: comments separating groups" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
@@ -176,7 +176,19 @@ test "buildSortedImportText: comments separating groups" {
 }
 
 fn collectImportsForTest(source: [:0]const u8, block_end: usize) !std.ArrayListUnmanaged(zsort.Import) {
-    return zsort.collectImports(std.testing.allocator, source, block_end);
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    var imports: std.ArrayListUnmanaged(zsort.Import) = .empty;
+    errdefer imports.deinit(std.testing.allocator);
+    try imports.appendSlice(std.testing.allocator, analysis.imports.items);
+    for (imports.items) |*imp| imp.stray = imp.start >= block_end;
+    return imports;
+}
+
+fn blockEndForTest(source: [:0]const u8) usize {
+    var analysis = zsort.analyze(std.testing.allocator, source) catch return source.len;
+    defer analysis.deinit(std.testing.allocator);
+    return analysis.block_end;
 }
 
 fn collectAliasesForTest(source: [:0]const u8) !std.ArrayListUnmanaged(zsort.Import) {
@@ -200,10 +212,10 @@ test "hasBannedPatterns: backslash-prefixed lines ignored" {
 
 test "collectImports: braces in multiline-string line don't affect depth" {
     const source = "\\\\const a = struct {\nconst real = @import(\"real.zig\");\n";
-    var imports = try zsort.collectImports(std.testing.allocator, source, 0);
-    defer imports.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), imports.items.len);
-    try std.testing.expectEqualStrings("real.zig", imports.items[0].path);
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), analysis.imports.items.len);
+    try std.testing.expectEqualStrings("real.zig", analysis.imports.items[0].path);
 }
 
 test "findImportBlockEnd: stops before unterminated alias line" {
@@ -213,7 +225,7 @@ test "findImportBlockEnd: stops before unterminated alias line" {
         \\const Allocator = std.mem
         \\    .Allocator;
     ;
-    try std.testing.expectEqual("const std = @import(\"std\");\n\n".len, zsort.findImportBlockEnd(source));
+    try std.testing.expectEqual("const std = @import(\"std\");\n\n".len, blockEndForTest(source));
 }
 
 test "processSource: hoists multiline stray import intact" {
@@ -308,6 +320,8 @@ test "processSource: import expression ending in brace terminates" {
     const result = try zsort.processSource(std.testing.allocator, source, &.{});
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
+    defer if (result.banned_msg) |msg| std.testing.allocator.free(msg);
+    try std.testing.expect(result.banned);
     try std.testing.expect(!result.changed);
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.new_text, "const x = @import"));
 }
@@ -367,7 +381,9 @@ test "processSource: idempotent" {
     const r1 = try zsort.processSource(std.testing.allocator, source, &.{});
     defer std.testing.allocator.free(r1.new_text);
     defer std.testing.allocator.free(r1.new_block);
-    const r2 = try zsort.processSource(std.testing.allocator, r1.new_text, &.{});
+    const r1_z = try std.testing.allocator.dupeZ(u8, r1.new_text);
+    defer std.testing.allocator.free(r1_z);
+    const r2 = try zsort.processSource(std.testing.allocator, r1_z, &.{});
     defer std.testing.allocator.free(r2.new_text);
     defer std.testing.allocator.free(r2.new_block);
     try std.testing.expect(!r2.changed);
@@ -540,7 +556,7 @@ test "collectImports: classes and sorted order" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 3), imports.items.len);
@@ -561,7 +577,7 @@ test "buildSortedImportText: comment travels with its import" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
@@ -582,7 +598,7 @@ test "buildSortedImportText: alias imports hoisted after imports" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
@@ -720,7 +736,9 @@ test "processSource: trailing comment on multiline import travels" {
     try std.testing.expect(result.changed);
     const late_pos = std.mem.indexOf(u8, result.new_text, "const late") orelse return error.TestUnexpectedResult;
     const joined_pos = std.mem.indexOf(u8, result.new_text, "); // late comment") orelse return error.TestUnexpectedResult;
+    const main_pos = std.mem.indexOf(u8, result.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
     try std.testing.expect(joined_pos > late_pos);
+    try std.testing.expect(joined_pos < main_pos);
 }
 
 test "processSource: cimport block kept intact" {
@@ -774,7 +792,7 @@ test "buildSortedImportText: comment above alias travels" {
         \\
         \\const rest = 1;
     ;
-    const block_end = zsort.findImportBlockEnd(source);
+    const block_end = blockEndForTest(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -24,52 +24,6 @@ test "classify: local" {
     try std.testing.expectEqual(zsort.class_local, zsort.classify("build_root"));
 }
 
-test "extractPath: normal" {
-    try std.testing.expectEqualStrings("bar", zsort.extractPath("@import(\"bar\")", "@import(").?);
-}
-
-test "extractPath: null on malformed" {
-    try std.testing.expectEqual(@as(?[]const u8, null), zsort.extractPath("@import(bar)", "@import("));
-    try std.testing.expectEqual(@as(?[]const u8, null), zsort.extractPath("noimport", "@import("));
-}
-
-test "isTopLevelImportLine: basic import" {
-    try std.testing.expect(zsort.isTopLevelImportLine("const std = @import(\"std\");\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("pub const foo = @import(\"foo\");\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("_ = @import(\"bar\");\n"));
-}
-
-test "isTopLevelImportLine: semicolon terminated alias" {
-    try std.testing.expect(zsort.isTopLevelImportLine("const Payload = msgpack.Payload;\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const Debug = std.debug;\n"));
-}
-
-test "isTopLevelImportLine: alias to struct-like module name" {
-    try std.testing.expect(zsort.isTopLevelImportLine("const Enum = enums.Kind;\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const Union = unions.Kind;\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const Opaque = opaques.Handle;\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const Structs = structs.Kind;\n"));
-}
-
-test "isTopLevelImportLine: trailing type-keyword comment on import line" {
-    try std.testing.expect(zsort.isTopLevelImportLine("const x = @import(\"a\"); // = struct\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const x = @import(\"a\"); // = enum\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const x = @import(\"a\"); // = union\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const x = @import(\"a\"); // = opaque\n"));
-}
-
-test "isTopLevelImportLine: not import lines" {
-    try std.testing.expect(!zsort.isTopLevelImportLine("const S = struct {\n"));
-    try std.testing.expect(!zsort.isTopLevelImportLine("const E = enum {\n"));
-    try std.testing.expect(!zsort.isTopLevelImportLine("pub fn main() !void {\n"));
-}
-
-test "isTopLevelImportLine: comments and empty lines" {
-    try std.testing.expect(zsort.isTopLevelImportLine("// some comment\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("  \t\n"));
-}
-
 test "findImportBlockEnd: ends at first non-import" {
     const source =
         \\const std = @import("std");
@@ -89,34 +43,6 @@ test "findImportBlockEnd: alias to struct-like module does not end block" {
         "const std = @import(\"std\");\nconst Enum = enums.Kind;\nconst Other = @import(\"other\");".len,
         zsort.findImportBlockEnd(source),
     );
-}
-
-test "findCImportEnd: basic block" {
-    const source =
-        \\const c = @cImport({
-        \\    int x = 1;
-        \\});
-        \\
-        \\const rest = 42;
-    ;
-    const cimport_pos = std.mem.indexOf(u8, source, "@cImport(") orelse return error.TestFailed;
-    const end = zsort.findCImportEnd(source, cimport_pos);
-    try std.testing.expect(end > cimport_pos);
-    try std.testing.expect(std.mem.indexOf(u8, source[end..], "const rest") != null);
-}
-
-test "findCImportEnd: braces in strings ignored" {
-    const source =
-        \\const c = @cImport({
-        \\    printf("{ hello }");
-        \\});
-        \\
-        \\const rest = 42;
-    ;
-    const cimport_pos = std.mem.indexOf(u8, source, "@cImport(") orelse return error.TestFailed;
-    const end = zsort.findCImportEnd(source, cimport_pos);
-    try std.testing.expect(end > cimport_pos);
-    try std.testing.expect(std.mem.indexOf(u8, source[end..], "const rest") != null);
 }
 
 test "hasBannedPatterns: no problems" {
@@ -180,8 +106,10 @@ test "buildSortedImportText: basic sort" {
     const block_end = zsort.findImportBlockEnd(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
 
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
     defer std.testing.allocator.free(result);
 
     const pos_std = std.mem.indexOf(u8, result, "std") orelse return error.TestUnexpectedResult;
@@ -201,7 +129,9 @@ test "buildSortedImportText: idempotent fix twice" {
     const block_end1 = zsort.findImportBlockEnd(source);
     var imports1 = try collectImportsForTest(source, block_end1);
     defer imports1.deinit(std.testing.allocator);
-    const pass1 = try zsort.buildSortedImportText(std.testing.allocator, source, imports1.items, block_end1);
+    var aliases1 = try collectAliasesForTest(source);
+    defer aliases1.deinit(std.testing.allocator);
+    const pass1 = try zsort.buildSortedImportText(std.testing.allocator, source, imports1.items, aliases1.items, block_end1);
     defer std.testing.allocator.free(pass1);
 
     var full1: std.ArrayListUnmanaged(u8) = .empty;
@@ -209,10 +139,14 @@ test "buildSortedImportText: idempotent fix twice" {
     try full1.appendSlice(std.testing.allocator, pass1);
     try full1.appendSlice(std.testing.allocator, source[block_end1..]);
 
-    const block_end2 = zsort.findImportBlockEnd(full1.items);
-    var imports2 = try collectImportsForTest(full1.items, block_end2);
+    const full1_z = try std.testing.allocator.dupeZ(u8, full1.items);
+    defer std.testing.allocator.free(full1_z);
+    const block_end2 = zsort.findImportBlockEnd(full1_z);
+    var imports2 = try collectImportsForTest(full1_z, block_end2);
     defer imports2.deinit(std.testing.allocator);
-    const pass2 = try zsort.buildSortedImportText(std.testing.allocator, full1.items, imports2.items, block_end2);
+    var aliases2 = try collectAliasesForTest(full1_z);
+    defer aliases2.deinit(std.testing.allocator);
+    const pass2 = try zsort.buildSortedImportText(std.testing.allocator, full1_z, imports2.items, aliases2.items, block_end2);
     defer std.testing.allocator.free(pass2);
 
     try std.testing.expectEqualStrings(pass1, pass2);
@@ -230,8 +164,10 @@ test "buildSortedImportText: comments separating groups" {
     const block_end = zsort.findImportBlockEnd(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
 
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
     defer std.testing.allocator.free(result);
 
     try std.testing.expect(std.mem.indexOf(u8, result, "// Third-party imports") != null);
@@ -239,8 +175,17 @@ test "buildSortedImportText: comments separating groups" {
     try std.testing.expect(std.mem.indexOf(u8, result, "sqlite") != null);
 }
 
-fn collectImportsForTest(source: []const u8, block_end: usize) !std.ArrayListUnmanaged(zsort.Import) {
+fn collectImportsForTest(source: [:0]const u8, block_end: usize) !std.ArrayListUnmanaged(zsort.Import) {
     return zsort.collectImports(std.testing.allocator, source, block_end);
+}
+
+fn collectAliasesForTest(source: [:0]const u8) !std.ArrayListUnmanaged(zsort.Import) {
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    var aliases: std.ArrayListUnmanaged(zsort.Import) = .empty;
+    errdefer aliases.deinit(std.testing.allocator);
+    try aliases.appendSlice(std.testing.allocator, analysis.aliases.items);
+    return aliases;
 }
 
 test "hasBannedPatterns: self-scan clean" {
@@ -259,12 +204,6 @@ test "collectImports: braces in multiline-string line don't affect depth" {
     defer imports.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), imports.items.len);
     try std.testing.expectEqualStrings("real.zig", imports.items[0].path);
-}
-
-test "isTopLevelImportLine: unterminated lines are not import lines" {
-    try std.testing.expect(!zsort.isTopLevelImportLine("const Allocator = std.mem\n"));
-    try std.testing.expect(!zsort.isTopLevelImportLine("const x = @import(\"a\")\n"));
-    try std.testing.expect(zsort.isTopLevelImportLine("const x = @import(\"a\"); // comment\n"));
 }
 
 test "findImportBlockEnd: stops before unterminated alias line" {
@@ -625,7 +564,9 @@ test "buildSortedImportText: comment travels with its import" {
     const block_end = zsort.findImportBlockEnd(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, block_end);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
     defer std.testing.allocator.free(result);
     const std_pos = std.mem.indexOf(u8, result, "const std") orelse return error.TestUnexpectedResult;
     const bar_pos = std.mem.indexOf(u8, result, "const bar") orelse return error.TestUnexpectedResult;
@@ -644,7 +585,9 @@ test "buildSortedImportText: alias imports hoisted after imports" {
     const block_end = zsort.findImportBlockEnd(source);
     var imports = try collectImportsForTest(source, block_end);
     defer imports.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, block_end);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
     defer std.testing.allocator.free(result);
     const bar_pos = std.mem.indexOf(u8, result, "const bar") orelse return error.TestUnexpectedResult;
     const debug_pos = std.mem.indexOf(u8, result, "const Debug = std.debug;") orelse return error.TestUnexpectedResult;
@@ -670,6 +613,177 @@ test "processSource: hoisted stray import lands in its group" {
     try std.testing.expect(std_pos < bar_pos);
     try std.testing.expect(bar_pos < late_pos);
     try std.testing.expect(std.mem.indexOf(u8, result.new_text, "pub fn main") != null);
+}
+
+test "analyze: typed import is collected" {
+    const source = "const x: SomeType = @import(\"a\");\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), analysis.imports.items.len);
+    try std.testing.expectEqualStrings("a", analysis.imports.items[0].path);
+}
+
+test "analyze: var import is not collected" {
+    const source = "var x = @import(\"a\");\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
+}
+
+test "analyze: bare underscore import is not collected" {
+    const source = "_ = @import(\"x\");\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
+}
+
+test "analyze: spaced-dot alias stops the block" {
+    const source = "const std = @import(\"std\");\nconst Debug = std . debug;\n";
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.aliases.items.len);
+    try std.testing.expectEqual("const std = @import(\"std\");\n".len, analysis.block_end);
+}
+
+test "analyze: alias after the block is left alone" {
+    const source =
+        \\const std = @import("std");
+        \\pub fn main() {}
+        \\const Debug = std.debug;
+    ;
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.aliases.items.len);
+}
+
+test "analyze: nested re-export import is not collected" {
+    const source =
+        \\const lib = struct {
+        \\    pub const http = @import("httpz");
+        \\};
+    ;
+    var analysis = try zsort.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
+}
+
+test "hasBannedPatterns: nested re-export import not banned" {
+    const source =
+        \\const lib = struct {
+        \\    pub const http = @import("httpz");
+        \\};
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), try zsort.hasBannedPatterns(std.testing.allocator, source, &.{}));
+}
+
+test "hasBannedPatterns: dotted import alias not banned" {
+    const source = "const Allocator = @import(\"std\").heap.ArenaAllocator;\n";
+    try std.testing.expectEqual(@as(?[]const u8, null), try zsort.hasBannedPatterns(std.testing.allocator, source, &.{}));
+}
+
+test "hasBannedPatterns: typed import with banned prefix detected" {
+    const source = "const x: T = @import(\"./bar\");\n";
+    const msg = try zsort.hasBannedPatterns(std.testing.allocator, source, &.{"./"}) orelse return error.TestFailed;
+    defer std.testing.allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "./") != null);
+}
+
+test "processSource: typed import hoisted and sorted" {
+    const source =
+        \\const bar = @import("bar");
+        \\const x: SomeType = @import("a");
+        \\
+        \\pub fn main() {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const a_pos = std.mem.indexOf(u8, result.new_text, "const x: SomeType") orelse return error.TestUnexpectedResult;
+    const bar_pos = std.mem.indexOf(u8, result.new_text, "const bar") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(a_pos < bar_pos);
+}
+
+test "processSource: trailing comment on multiline import travels" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\pub fn main() {}
+        \\
+        \\const late = @import(
+        \\    "late.zig"
+        \\); // late comment
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const late_pos = std.mem.indexOf(u8, result.new_text, "const late") orelse return error.TestUnexpectedResult;
+    const joined_pos = std.mem.indexOf(u8, result.new_text, "); // late comment") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(joined_pos > late_pos);
+}
+
+test "processSource: cimport block kept intact" {
+    const source =
+        \\const c = @cImport({
+        \\    #include <stdio.h>
+        \\}); // c trailing
+        \\const rest = 1;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(!result.changed);
+    try std.testing.expectEqualStrings(source, result.new_text);
+}
+
+test "processSource: stray cimport hoisted" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\pub fn main() {}
+        \\const c = @cImport({
+        \\    #include <x.h>
+        \\});
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const c_pos = std.mem.indexOf(u8, result.new_text, "const c = @cImport") orelse return error.TestUnexpectedResult;
+    const main_pos = std.mem.indexOf(u8, result.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(c_pos < main_pos);
+}
+
+test "processSource: comment-only file unchanged" {
+    const source = "// just comments\n// more\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    defer if (result.changed) {
+        std.testing.allocator.free(result.new_text);
+        std.testing.allocator.free(result.new_block);
+    };
+    try std.testing.expect(!result.changed);
+    try std.testing.expectEqualStrings(source, result.new_text);
+}
+
+test "buildSortedImportText: comment above alias travels" {
+    const source =
+        \\const bar = @import("bar");
+        \\// Debug alias
+        \\const Debug = std.debug;
+        \\
+        \\const rest = 1;
+    ;
+    const block_end = zsort.findImportBlockEnd(source);
+    var imports = try collectImportsForTest(source, block_end);
+    defer imports.deinit(std.testing.allocator);
+    var aliases = try collectAliasesForTest(source);
+    defer aliases.deinit(std.testing.allocator);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    defer std.testing.allocator.free(result);
+    const comment_pos = std.mem.indexOf(u8, result, "// Debug alias") orelse return error.TestUnexpectedResult;
+    const debug_pos = std.mem.indexOf(u8, result, "const Debug") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(comment_pos < debug_pos);
 }
 
 test "parseArgs: check mode with prefixes" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved import sorting for typed, aliased, multiline, and C imports.
  - Preserves comments and handles nested or inline imports correctly.
  - Detects and removes stray imports while retaining supported aliases.
  - Supports escaped import paths and more consistent import classification.

- **Bug Fixes**
  - Improved handling of malformed or mixed import blocks.
  - Enhanced banned-import detection for more reliable validation.
  - Ensured unchanged files remain untouched when sorting is unnecessary.

- **Documentation**
  - Clarified that `zsort fix` organizes explicitly typed imports like regular imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->