### PR TITLE
Improve CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Banned-import messages now include the offending line number; summary
+  lines omit `failed`/`banned` counts when they are zero
+
 ### Added
 
 - Multiple targets: `zsort [check|fix] <path>...` accepts any mix of files

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -77,15 +77,17 @@ fn scanBannedPatterns(
     allocator: std.mem.Allocator,
     analysis: *const ast_scan.Analysis,
     banned_prefixes: []const []const u8,
+    source: []const u8,
 ) !?[]const u8 {
     for (analysis.calls.items) |call| {
+        const line = std.mem.count(u8, source[0..call.offset], "\n") + 1;
         if (std.mem.indexOfScalar(usize, analysis.allowed.items, call.offset) == null) {
-            return allocFmt(allocator, "inline @import inside a type expression", .{}) orelse return error.OutOfMemory;
+            return allocFmt(allocator, "inline @import inside a type expression (line {d})", .{line}) orelse return error.OutOfMemory;
         }
         if (call.path) |path| {
             for (banned_prefixes) |prefix| {
                 if (std.mem.startsWith(u8, path, prefix)) {
-                    return allocFmt(allocator, "imports from '{s}' are not allowed", .{prefix}) orelse return error.OutOfMemory;
+                    return allocFmt(allocator, "imports from '{s}' are not allowed (line {d})", .{ prefix, line }) orelse return error.OutOfMemory;
                 }
             }
         }
@@ -102,7 +104,7 @@ pub fn hasBannedPatterns(
     defer allocator.free(dup);
     var analysis = try ast_scan.analyze(allocator, dup);
     defer analysis.deinit(allocator);
-    return scanBannedPatterns(allocator, &analysis, banned_prefixes);
+    return scanBannedPatterns(allocator, &analysis, banned_prefixes, source);
 }
 
 fn detectNewline(source: []const u8) []const u8 {
@@ -499,7 +501,7 @@ pub fn processSource(
     const imports = analysis.imports.items;
     const aliases = analysis.aliases.items;
 
-    const banned_msg = try scanBannedPatterns(allocator, &analysis, banned_prefixes);
+    const banned_msg = try scanBannedPatterns(allocator, &analysis, banned_prefixes, source);
     errdefer if (banned_msg) |msg| allocator.free(msg);
 
     if (imports.len == 0) {
@@ -676,18 +678,32 @@ pub fn formatSummary(
     const reset = compat.ansi(use_color, compat.ansi_reset);
     const file_word = if (stats.files == 1) "file" else "files";
     const ms = @divTrunc(stats.elapsed_ns, std.time.ns_per_ms);
-    return switch (mode) {
-        .check => allocFmt(
-            allocator,
-            "  Found {[0]s}{[2]d}{[1]s} of {[0]s}{[6]d}{[1]s} {[7]s} to fix, {[3]s}{[4]d}{[1]s} failed, {[5]s}{[8]d}{[1]s} banned in {[0]s}{[9]d}{[1]s}ms.\n",
-            .{ yellow, reset, stats.changed, red, stats.errors, magenta, stats.files, file_word, stats.banned, ms },
-        ),
-        .fix => allocFmt(
-            allocator,
-            "\n  Fixed {[0]s}{[2]d}{[1]s} of {[0]s}{[6]d}{[1]s} {[7]s}, {[3]s}{[4]d}{[1]s} failed, {[5]s}{[8]d}{[1]s} banned in {[0]s}{[9]d}{[1]s}ms.\n",
-            .{ yellow, reset, stats.changed, red, stats.errors, magenta, stats.files, file_word, stats.banned, ms },
-        ),
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    const head = switch (mode) {
+        .check => allocFmt(allocator, "  Found {s}{d}{s} of {s}{d}{s} {s} to fix", .{ yellow, stats.changed, reset, yellow, stats.files, reset, file_word }) orelse return null,
+        .fix => allocFmt(allocator, "\n  Fixed {s}{d}{s} of {s}{d}{s} {s}", .{ yellow, stats.changed, reset, yellow, stats.files, reset, file_word }) orelse return null,
     };
+    defer allocator.free(head);
+    out.appendSlice(allocator, head) catch return null;
+
+    if (stats.errors > 0) {
+        const seg = allocFmt(allocator, ", {s}{d}{s} failed", .{ red, stats.errors, reset }) orelse return null;
+        defer allocator.free(seg);
+        out.appendSlice(allocator, seg) catch return null;
+    }
+    if (stats.banned > 0) {
+        const seg = allocFmt(allocator, ", {s}{d}{s} banned", .{ magenta, stats.banned, reset }) orelse return null;
+        defer allocator.free(seg);
+        out.appendSlice(allocator, seg) catch return null;
+    }
+
+    const tail = allocFmt(allocator, " in {s}{d}{s}ms.\n", .{ yellow, ms, reset }) orelse return null;
+    defer allocator.free(tail);
+    out.appendSlice(allocator, tail) catch return null;
+    const owned = out.toOwnedSlice(allocator) catch return null;
+    return owned;
 }
 
 fn printHelp(io: compat.Io, use_color: bool) void {

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -93,6 +93,7 @@ test "hasBannedPatterns: inline @import detected even without prefixes" {
     const source = "fn foo() @import(\"bar\").Type {\n}\n";
     const msg = try zsort.hasBannedPatterns(std.testing.allocator, source, &.{}) orelse return error.TestFailed;
     defer std.testing.allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "(line 1)") != null);
 }
 
 test "buildSortedImportText: basic sort" {
@@ -1045,6 +1046,18 @@ test "hasBannedPatterns: typed import with banned prefix detected" {
     const msg = try zsort.hasBannedPatterns(std.testing.allocator, source, &.{"./"}) orelse return error.TestFailed;
     defer std.testing.allocator.free(msg);
     try std.testing.expect(std.mem.indexOf(u8, msg, "./") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "(line 1)") != null);
+}
+
+test "hasBannedPatterns: message includes the offending line number" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\const bar = @import("./bar");
+    ;
+    const msg = try zsort.hasBannedPatterns(std.testing.allocator, source, &.{"./"}) orelse return error.TestFailed;
+    defer std.testing.allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "(line 3)") != null);
 }
 
 test "processSource: typed import hoisted and sorted" {
@@ -1240,7 +1253,7 @@ test "formatSummary: check mode, plain without color" {
         .elapsed_ns = 12 * std.time.ns_per_ms,
     }, .check, false) orelse return error.TestUnexpectedResult;
     defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("  Found 1 of 179 files to fix, 2 failed, 0 banned in 12ms.\n", s);
+    try std.testing.expectEqualStrings("  Found 1 of 179 files to fix, 2 failed in 12ms.\n", s);
 }
 
 test "formatSummary: fix mode, plain without color" {
@@ -1252,7 +1265,7 @@ test "formatSummary: fix mode, plain without color" {
         .elapsed_ns = 500_000,
     }, .fix, false) orelse return error.TestUnexpectedResult;
     defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("\n  Fixed 0 of 179 files, 0 failed, 0 banned in 0ms.\n", s);
+    try std.testing.expectEqualStrings("\n  Fixed 0 of 179 files in 0ms.\n", s);
 }
 
 test "formatSummary: colorized per-category numbers, sub-ms truncates to 0ms" {
@@ -1264,7 +1277,7 @@ test "formatSummary: colorized per-category numbers, sub-ms truncates to 0ms" {
         .elapsed_ns = 500_000,
     }, .check, true) orelse return error.TestUnexpectedResult;
     defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("  Found \x1b[33m0\x1b[0m of \x1b[33m179\x1b[0m files to fix, \x1b[31m0\x1b[0m failed, \x1b[35m0\x1b[0m banned in \x1b[33m0\x1b[0mms.\n", s);
+    try std.testing.expectEqualStrings("  Found \x1b[33m0\x1b[0m of \x1b[33m179\x1b[0m files to fix in \x1b[33m0\x1b[0mms.\n", s);
     try std.testing.expect(std.mem.indexOf(u8, s, "\x1b[") != null);
 }
 
@@ -1289,5 +1302,29 @@ test "formatSummary: single-file target uses singular 'file'" {
         .elapsed_ns = 2 * std.time.ns_per_ms,
     }, .check, false) orelse return error.TestUnexpectedResult;
     defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("  Found 1 of 1 file to fix, 0 failed, 0 banned in 2ms.\n", s);
+    try std.testing.expectEqualStrings("  Found 1 of 1 file to fix in 2ms.\n", s);
+}
+
+test "formatSummary: banned-only segment shown, failed omitted" {
+    const s = zsort.formatSummary(std.testing.allocator, .{
+        .changed = 1,
+        .errors = 0,
+        .banned = 3,
+        .files = 4,
+        .elapsed_ns = 0,
+    }, .check, true) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("  Found \x1b[33m1\x1b[0m of \x1b[33m4\x1b[0m files to fix, \x1b[35m3\x1b[0m banned in \x1b[33m0\x1b[0mms.\n", s);
+}
+
+test "formatSummary: failed and banned segments both shown in order" {
+    const s = zsort.formatSummary(std.testing.allocator, .{
+        .changed = 1,
+        .errors = 2,
+        .banned = 3,
+        .files = 4,
+        .elapsed_ns = 5 * std.time.ns_per_ms,
+    }, .check, false) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("  Found 1 of 4 files to fix, 2 failed, 3 banned in 5ms.\n", s);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Banned-import diagnostics now include the source line where the issue occurs.
  * Summary output now omits failure and banned counts when their values are zero.
  * Summary wording and formatting are more accurate for singular files and banned-only results.

* **Documentation**
  * Updated the unreleased changelog to describe the diagnostic and summary improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->