### PR TITLE
feat: implement support for import at the bottom of the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `--bottom` flag places the entire import block (imports, aliases, and
+  their attached comments) at the end of the file, keeping `//!` doc
+  comments and detached header comments at the top; works with both
+  `check` and `fix`
+
 ## [0.6.0] - 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Modes:
 
 Options:
   --ban-prefix <p>   Reject imports starting with <p> (repeatable)
+  --bottom           Place the import block at the end of the file
   -h, --help         Show help
   --version          Print version
 ```
@@ -84,6 +85,7 @@ zsort check src/                                  # verify a directory
 zsort fix .                                       # fix everything
 zsort check src/ build.zig                        # mixed targets
 zsort check . --ban-prefix ./ --ban-prefix src/   # ban relative paths
+zsort fix . --bottom                              # imports at the end of the file
 ```
 
 - `check` prints unified diffs for files that need changes.
@@ -141,6 +143,12 @@ const Config = auth.Config;
 - Keeps preceding comments attached to their import
 - Ensures a blank line between the import block and the following code
 - Preserves `//!` doc comments and original line endings (LF / CRLF)
+
+With `--bottom`, the whole block instead moves to the end of the file (the
+layout used by `zig init` templates): `//!` doc comments and comments
+detached by a blank line stay at the top, comments directly attached to an
+import travel with it, and comments after the last import stay with the
+body. The sort order and bands are unchanged.
 
 ## Pre-commit
 

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -52,7 +52,7 @@ pub fn classify(path: []const u8) u2 {
     return class_third_party;
 }
 
-fn findLineStart(source: []const u8, pos: usize) usize {
+pub fn findLineStart(source: []const u8, pos: usize) usize {
     var i = pos;
     while (i > 0) : (i -= 1) {
         if (source[i - 1] == '\n') return i;

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -8,6 +8,7 @@ const version = @import("version.zig").version;
 
 const Import = ast_scan.Import;
 const findLineEnd = ast_scan.findLineEnd;
+const findLineStart = ast_scan.findLineStart;
 
 /// Emit the comment block attached to a decl (`source[comment_start..imp.start]`),
 /// dropping blank lines: `findCommentStart` walks back over blanks, but a
@@ -157,6 +158,7 @@ pub fn buildSortedImportText(
     sorted_imports: []const Import,
     aliases: []const Import,
     block_end: usize,
+    bottom: bool,
 ) ![]const u8 {
     var preamble_lines: std.ArrayListUnmanaged([]const u8) = .empty;
     defer preamble_lines.deinit(allocator);
@@ -228,16 +230,35 @@ pub fn buildSortedImportText(
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(allocator);
 
-    for (preamble_lines.items) |line| {
-        try buf.appendSlice(allocator, line);
-    }
-    if (preamble_lines.items.len > 0 and buf.items[buf.items.len - 1] != '\n') {
-        try buf.appendSlice(allocator, nl);
+    if (bottom) {
+        // The comment run directly above the first import is attached to it
+        // and travels with the block as its lead; everything above that run
+        // (`//!` docs, detached headers, blanks) stays at the top of the
+        // file, where processSource emits it. The first top-region span has
+        // comment_start == null (its run reaches line 0), so this is the
+        // only place its attached comments are emitted.
+        var first_start: usize = source.len;
+        for (sorted_imports) |imp| first_start = @min(first_start, imp.start);
+        for (aliases) |a| first_start = @min(first_start, a.start);
+        if (first_start < block_end) {
+            const line_start = findLineStart(source, first_start);
+            try buf.appendSlice(allocator, source[attachedCommentHeadStart(source, line_start)..line_start]);
+        }
+    } else {
+        for (preamble_lines.items) |line| {
+            try buf.appendSlice(allocator, line);
+        }
+        if (preamble_lines.items.len > 0 and buf.items[buf.items.len - 1] != '\n') {
+            try buf.appendSlice(allocator, nl);
+        }
     }
 
     try buf.appendSlice(allocator, imports_buf.items);
 
-    if (trailing_comments.items.len > 0) {
+    // In bottom mode the trailing comments stay with the body (processSource
+    // keeps them via the middle pass); only top mode attaches them to the
+    // end of the block, where they sit above the first body decl.
+    if (trailing_comments.items.len > 0 and !bottom) {
         try buf.appendSlice(allocator, nl);
         for (trailing_comments.items) |line| {
             try buf.appendSlice(allocator, line);
@@ -524,6 +545,63 @@ fn hasSkipComment(source: []const u8) bool {
     return false;
 }
 
+/// Start of the contiguous comment run directly above `line_start`: walks up
+/// over `//` lines (excluding `//!`, which document the module and never
+/// travel) and stops at the first blank or non-comment line. The returned
+/// range is attached to the code below; everything above it is detached
+/// header material. Only used by the `--bottom` layout.
+fn attachedCommentHeadStart(source: []const u8, line_start: usize) usize {
+    var pos = line_start;
+    while (pos > 0) {
+        const ls = findLineStart(source, pos - 1);
+        const trimmed = std.mem.trim(u8, source[ls..pos], " \t\r\n");
+        if (std.mem.startsWith(u8, trimmed, "//") and !std.mem.startsWith(u8, trimmed, "//!")) {
+            pos = ls;
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+/// Append the `//`-prefixed lines of `source[start..end]`, dropping blank
+/// lines. Keeps the trailing comments of the import block with the body when
+/// the block itself moves to the end of the file.
+fn appendCommentLines(allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8), source: []const u8, start: usize, end: usize) !void {
+    var pos = start;
+    while (pos < end) {
+        const le = findLineEnd(source, pos);
+        const trimmed = std.mem.trimStart(u8, source[pos..le], " \t\r\n");
+        if (std.mem.startsWith(u8, trimmed, "//")) {
+            try buf.appendSlice(allocator, source[pos..le]);
+        }
+        pos = le;
+    }
+}
+
+const SortByStart = struct {
+    fn lt(_: void, a: Import, b: Import) bool {
+        return a.start < b.start;
+    }
+};
+
+/// Remove the stray spans from `source[block_end..]`, appending the gaps to
+/// `buf`: each span's comment window (first non-blank line of its attached
+/// comments) travels with it, while blank lines separating the import from
+/// the code above survive the removal.
+fn removeStrays(allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8), source: []const u8, block_end: usize, strays: []const Import) !void {
+    var pos: usize = block_end;
+    for (strays) |imp| {
+        var raw_start = imp.start;
+        if (imp.comment_start) |cs| raw_start = firstNonBlankLineStart(source, cs, imp.start);
+        const removal_start = @max(raw_start, pos);
+        if (imp.end <= pos) continue;
+        try buf.appendSlice(allocator, source[pos..removal_start]);
+        pos = imp.end;
+    }
+    try buf.appendSlice(allocator, source[pos..]);
+}
+
 const ProcessResult = struct {
     new_text: []const u8,
     new_block: []const u8,
@@ -540,6 +618,7 @@ pub fn processSource(
     allocator: std.mem.Allocator,
     source: [:0]const u8,
     banned_prefixes: []const []const u8,
+    bottom: bool,
 ) !ProcessResult {
     if (hasSkipComment(source)) {
         return .{
@@ -587,38 +666,110 @@ pub fn processSource(
             try stray_imports.append(allocator, alias);
         }
     }
+    if (stray_imports.items.len > 0) {
+        std.sort.pdq(Import, stray_imports.items, {}, SortByStart.lt);
+    }
+
+    const nl = detectNewline(source);
 
     var rest: []const u8 = source[block_end..];
     var rest_owned: ?[]const u8 = null;
     errdefer if (rest_owned) |owned| allocator.free(owned);
-    if (stray_imports.items.len > 0) {
-        std.sort.pdq(Import, stray_imports.items, {}, struct {
-            fn lt(_: void, a: Import, b: Import) bool {
-                return a.start < b.start;
+    var top_cut: usize = block_end;
+    if (bottom) {
+        var first_span_line_start: usize = source.len;
+        for (imports) |imp| first_span_line_start = @min(first_span_line_start, findLineStart(source, imp.start));
+        for (aliases) |alias| first_span_line_start = @min(first_span_line_start, findLineStart(source, alias.start));
+
+        // The preamble (//! docs, detached headers, blanks) stays at the top
+        // of the file; the comment run directly above the first import is
+        // attached to it and travels with the block. Trailing blank lines of
+        // the preamble are trimmed — the seam below re-inserts one.
+        top_cut = @min(block_end, attachedCommentHeadStart(source, first_span_line_start));
+        while (top_cut > 0) {
+            const ls = findLineStart(source, top_cut - 1);
+            if (std.mem.trim(u8, source[ls..top_cut], " \t\r\n").len == 0) {
+                top_cut = ls;
+            } else {
+                break;
             }
-        }.lt);
+        }
+
+        var rest_buf: std.ArrayListUnmanaged(u8) = .empty;
+        defer rest_buf.deinit(allocator);
+
+        // Drop the top-region spans (with their attached comments), keeping
+        // only comment lines: inter-span blanks were the block's internal
+        // band separation and are rebuilt by the block, while comments after
+        // the last span stay attached to the body decl below them.
+        var top_spans: std.ArrayListUnmanaged(Import) = .empty;
+        defer top_spans.deinit(allocator);
+        for (imports) |imp| {
+            if (imp.start < block_end) try top_spans.append(allocator, imp);
+        }
+        for (aliases) |alias| {
+            if (alias.start < block_end) try top_spans.append(allocator, alias);
+        }
+        if (top_spans.items.len > 0) {
+            std.sort.pdq(Import, top_spans.items, {}, SortByStart.lt);
+            var pos = first_span_line_start;
+            for (top_spans.items) |imp| {
+                var raw_start = imp.start;
+                if (imp.comment_start) |cs| raw_start = firstNonBlankLineStart(source, cs, imp.start);
+                const removal_start = @max(raw_start, pos);
+                if (imp.end <= pos) continue;
+                try appendCommentLines(allocator, &rest_buf, source, pos, removal_start);
+                pos = imp.end;
+            }
+            try appendCommentLines(allocator, &rest_buf, source, pos, block_end);
+        }
+        try removeStrays(allocator, &rest_buf, source, block_end, stray_imports.items);
+        const owned_rest = try rest_buf.toOwnedSlice(allocator);
+        rest_owned = owned_rest;
+        rest = owned_rest;
+    } else if (stray_imports.items.len > 0) {
         var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(allocator);
-        var pos: usize = block_end;
-        for (stray_imports.items) |imp| {
-            // The comment window starts at the first non-blank line so that
-            // blank lines separating the import from the code above survive
-            // the removal instead of being swallowed with it.
-            var raw_start = imp.start;
-            if (imp.comment_start) |cs| raw_start = firstNonBlankLineStart(source, cs, imp.start);
-            const removal_start = @max(raw_start, pos);
-            if (imp.end <= pos) continue;
-            try buf.appendSlice(allocator, source[pos..removal_start]);
-            pos = imp.end;
-        }
-        try buf.appendSlice(allocator, source[pos..]);
-        const owned = try buf.toOwnedSlice(allocator);
-        rest_owned = owned;
-        rest = owned;
+        try removeStrays(allocator, &buf, source, block_end, stray_imports.items);
+        const owned_rest = try buf.toOwnedSlice(allocator);
+        rest_owned = owned_rest;
+        rest = owned_rest;
     }
 
-    const new_imports = try buildSortedImportText(allocator, source, imports, aliases, block_end);
+    const new_imports = try buildSortedImportText(allocator, source, imports, aliases, block_end, bottom);
     errdefer allocator.free(new_imports);
+
+    if (bottom) {
+        // File layout: preamble, body, blank, import block. Exactly one blank
+        // line separates the preamble from the body and the body from the
+        // block; already-blank boundaries are not doubled.
+        var full_buf: std.ArrayListUnmanaged(u8) = .empty;
+        defer full_buf.deinit(allocator);
+        try full_buf.appendSlice(allocator, source[0..top_cut]);
+        if (top_cut > 0 and rest.len > 0) try full_buf.appendSlice(allocator, nl);
+        try full_buf.appendSlice(allocator, rest);
+        var junction = false;
+        if (full_buf.items.len > 0 and !endsWithBlankLine(full_buf.items)) {
+            junction = true;
+            // One newline terminates the body's last line, a second one
+            // turns it into the separating blank line.
+            try full_buf.appendSlice(allocator, nl);
+            if (!endsWithBlankLine(full_buf.items)) try full_buf.appendSlice(allocator, nl);
+        }
+        try full_buf.appendSlice(allocator, new_imports);
+        const owned = try full_buf.toOwnedSlice(allocator);
+        if (rest_owned) |owned_rest| allocator.free(owned_rest);
+        return .{
+            .new_text = owned,
+            .new_block = new_imports,
+            .block_end = top_cut,
+            .changed = !std.mem.eql(u8, source, owned),
+            .banned = banned_msg != null,
+            .banned_msg = banned_msg,
+            .stray_count = stray_imports.items.len,
+            .junction_blank = junction,
+        };
+    }
 
     const original_block = source[0..block_end];
     // The sorted block is separated from the body by a blank line unless the
@@ -643,7 +794,7 @@ pub fn processSource(
     const changed = !std.mem.eql(u8, original_block, new_imports) or stray_imports.items.len > 0 or junction_blank;
 
     const full_new = if (junction_blank)
-        try std.mem.concat(allocator, u8, &.{ new_imports, detectNewline(source), rest })
+        try std.mem.concat(allocator, u8, &.{ new_imports, nl, rest })
     else
         try std.mem.concat(allocator, u8, &.{ new_imports, rest });
     if (rest_owned) |owned| allocator.free(owned);
@@ -668,6 +819,7 @@ pub const Args = struct {
     mode: CliMode,
     targets: std.ArrayListUnmanaged([]const u8),
     banned_prefixes: std.ArrayListUnmanaged([]const u8),
+    bottom: bool = false,
     help: bool = false,
     version: bool = false,
 
@@ -687,6 +839,7 @@ pub fn parseArgs(
     var mode: ?CliMode = null;
     var help = false;
     var show_version = false;
+    var bottom = false;
 
     var targets: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer targets.deinit(allocator);
@@ -708,6 +861,8 @@ pub fn parseArgs(
             }
             i += 1;
             try banned_prefixes.append(allocator, args[i]);
+        } else if (std.mem.eql(u8, arg, "--bottom")) {
+            bottom = true;
         } else if (arg.len > 0 and arg[0] == '-') {
             err_msg.* = allocFmt(allocator, "Unknown option '{s}'", .{arg});
             return error.UnexpectedArg;
@@ -730,6 +885,7 @@ pub fn parseArgs(
             .mode = mode orelse .check,
             .targets = targets,
             .banned_prefixes = banned_prefixes,
+            .bottom = bottom,
             .help = help,
             .version = show_version,
         };
@@ -746,6 +902,7 @@ pub fn parseArgs(
         .mode = mode.?,
         .targets = targets,
         .banned_prefixes = banned_prefixes,
+        .bottom = bottom,
     };
 }
 
@@ -811,6 +968,7 @@ fn printHelp(io: compat.Io, use_color: bool) void {
             \\
             \\{[0]s}Options:{[1]s}
             \\  {[2]s}--ban-prefix <p>{[1]s}   Reject import paths starting with this prefix (repeatable)
+            \\  {[2]s}--bottom{[1]s}          Place the import block at the end of the file
             \\  {[2]s}-h, --help{[1]s}         Show this help message
             \\  {[2]s}--version{[1]s}          Print version and exit
             \\
@@ -827,6 +985,7 @@ fn printHelp(io: compat.Io, use_color: bool) void {
             \\
             \\Options:
             \\  --ban-prefix <p>   Reject import paths starting with this prefix (repeatable)
+            \\  --bottom          Place the import block at the end of the file
             \\  -h, --help         Show this help message
             \\  --version          Print version and exit
             \\
@@ -848,6 +1007,7 @@ const FileJob = struct {
     slot: *JobSlot,
     path: []const u8,
     banned: []const []const u8,
+    bottom: bool,
 };
 
 fn processFileJob(job: *const FileJob, io: compat.Io) void {
@@ -857,7 +1017,7 @@ fn processFileJob(job: *const FileJob, io: compat.Io) void {
         return;
     };
     job.slot.source = source;
-    job.slot.result = processSource(allocator, source, job.banned) catch |err| {
+    job.slot.result = processSource(allocator, source, job.banned, job.bottom) catch |err| {
         job.slot.proc_err = @errorName(err);
         return;
     };
@@ -987,6 +1147,7 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
             .slot = slot,
             .path = file_path,
             .banned = parsed.banned_prefixes.items,
+            .bottom = parsed.bottom,
         };
     }
 
@@ -1040,7 +1201,9 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
                 printStdout(io, "  {s}Fixed:{s} {s}{s}{s}\n", .{ out_green, out_reset, out_yellow, esc_path, out_reset });
             }
         } else {
-            if (result.stray_count > 0 or result.junction_blank) {
+            // The block moved to the end of the file; a block-only diff
+            // would show the whole file as moved, so diff the full text.
+            if (parsed.bottom or result.stray_count > 0 or result.junction_blank) {
                 showDiff(io, allocator, file_path, slot.source, result.new_text, color);
             } else {
                 showDiff(io, allocator, file_path, slot.source[0..result.block_end], result.new_block, color);

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -577,6 +577,12 @@ test "processSource: --bottom preserves CRLF line endings" {
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\r\n\r\n" ++
+            "const a = @import(\"a.zig\");\r\n" ++
+            "const b = @import(\"b.zig\");\r\n",
+        result.new_text,
+    );
     var prev: u8 = 0;
     for (result.new_text) |ch| {
         if (ch == '\n') try std.testing.expectEqual(@as(u8, '\r'), prev);

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -69,7 +69,7 @@ test "buildSortedImportText: basic sort" {
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
 
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
 
     const pos_std = std.mem.indexOf(u8, result, "std") orelse return error.TestUnexpectedResult;
@@ -91,7 +91,7 @@ test "buildSortedImportText: idempotent fix twice" {
     defer imports1.deinit(std.testing.allocator);
     var aliases1 = try collectAliasesForTest(source);
     defer aliases1.deinit(std.testing.allocator);
-    const pass1 = try zsort.buildSortedImportText(std.testing.allocator, source, imports1.items, aliases1.items, block_end1);
+    const pass1 = try zsort.buildSortedImportText(std.testing.allocator, source, imports1.items, aliases1.items, block_end1, false);
     defer std.testing.allocator.free(pass1);
 
     var full1: std.ArrayListUnmanaged(u8) = .empty;
@@ -106,7 +106,7 @@ test "buildSortedImportText: idempotent fix twice" {
     defer imports2.deinit(std.testing.allocator);
     var aliases2 = try collectAliasesForTest(full1_z);
     defer aliases2.deinit(std.testing.allocator);
-    const pass2 = try zsort.buildSortedImportText(std.testing.allocator, full1_z, imports2.items, aliases2.items, block_end2);
+    const pass2 = try zsort.buildSortedImportText(std.testing.allocator, full1_z, imports2.items, aliases2.items, block_end2, false);
     defer std.testing.allocator.free(pass2);
 
     try std.testing.expectEqualStrings(pass1, pass2);
@@ -127,7 +127,7 @@ test "buildSortedImportText: comments separating groups" {
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
 
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
 
     try std.testing.expect(std.mem.indexOf(u8, result, "// Third-party imports") != null);
@@ -180,7 +180,7 @@ test "processSource: hoists multiline stray import intact" {
         \\    "late.zig"
         \\);
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -195,7 +195,7 @@ test "processSource: blank line inserted between block and body" {
         \\
         \\const build_options = @import("build_options");
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -205,7 +205,7 @@ test "processSource: blank line inserted between block and body" {
 
 test "processSource: clean block abutting body gains a blank line" {
     const source = "const std = @import(\"std\");\npub fn main() {}\n";
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -219,7 +219,7 @@ test "processSource: no double blank when rest starts blank" {
         \\
         \\pub fn main() {}
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(!result.changed);
@@ -231,7 +231,7 @@ test "processSource: doc comment stays attached to the following decl" {
         \\/// Docs for the decl.
         \\pub fn main() {}
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -243,7 +243,7 @@ test "processSource: division-deref is not mistaken for a block comment" {
         \\const v = a/*b;
         \\const std = @import("std");
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer if (result.changed) {
         std.testing.allocator.free(result.new_text);
         std.testing.allocator.free(result.new_block);
@@ -263,7 +263,7 @@ test "processSource: blank line before multiline stray import does not invert sl
         \\    "late.zig"
         \\);
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -279,7 +279,7 @@ test "processSource: unterminated import at EOF terminates" {
         \\const late = @import(
         \\    "late.zig"
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -294,7 +294,7 @@ test "processSource: comment above multiline stray import does not invert slice"
         \\    "late.zig"
         \\);
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -308,7 +308,7 @@ test "processSource: import expression ending in brace terminates" {
         \\{
         \\};
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     defer if (result.banned_msg) |msg| std.testing.allocator.free(msg);
@@ -333,7 +333,7 @@ test "hasBannedPatterns: escaped path decoded before prefix check" {
 
 test "processSource: collapses consecutive CRLF blank lines" {
     const source = "// h\r\n\r\n\r\nconst bar = @import(\"bar\");\r\n\r\npub fn main() {}\r\n";
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -345,7 +345,7 @@ test "processSource: skip comment leaves file untouched" {
         \\// zsort: skip
         \\const bar = @import("bar");
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     try std.testing.expect(!result.changed);
     try std.testing.expectEqualStrings(source, result.new_text);
 }
@@ -358,7 +358,7 @@ test "processSource: file-leading //! block stays at top with out-of-order impor
         \\const b = @import("b.zig");
         \\const a = @import("a.zig");
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -376,12 +376,12 @@ test "processSource: idempotent" {
         \\pub fn main() !void {}
         \\const zz = @import("zz.zig");
     ;
-    const r1 = try zsort.processSource(std.testing.allocator, source, &.{});
+    const r1 = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(r1.new_text);
     defer std.testing.allocator.free(r1.new_block);
     const r1_z = try std.testing.allocator.dupeZ(u8, r1.new_text);
     defer std.testing.allocator.free(r1_z);
-    const r2 = try zsort.processSource(std.testing.allocator, r1_z, &.{});
+    const r2 = try zsort.processSource(std.testing.allocator, r1_z, &.{}, false);
     defer std.testing.allocator.free(r2.new_text);
     defer std.testing.allocator.free(r2.new_block);
     try std.testing.expect(!r2.changed);
@@ -390,7 +390,190 @@ test "processSource: idempotent" {
 
 test "processSource: preserves CRLF line endings" {
     const source = "const bar = @import(\"bar\");\r\nconst std = @import(\"std\");\r\n\r\npub fn main() !void {}\r\n";
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    var prev: u8 = 0;
+    for (result.new_text) |ch| {
+        if (ch == '\n') try std.testing.expectEqual(@as(u8, '\r'), prev);
+        prev = ch;
+    }
+}
+
+test "processSource: --bottom moves the import block to the end of the file" {
+    const source =
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom is idempotent on an already-bottom file" {
+    const source =
+        \\pub fn main() !void {}
+        \\
+        \\const a = @import("a.zig");
+        \\const b = @import("b.zig");
+        \\
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(!result.changed);
+    try std.testing.expectEqualStrings(source, result.new_text);
+}
+
+test "processSource: --bottom keeps //! docs at the top" {
+    const source =
+        \\//! Module docs.
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "//! Module docs.\n\npub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom collapses inter-import blank lines into one seam" {
+    const source =
+        \\//! Module docs.
+        \\
+        \\const b = @import("b.zig");
+        \\
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "//! Module docs.\n\npub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom hoists mid-file strays into the bottom block" {
+    const source =
+        \\pub fn main() !void {}
+        \\
+        \\const zz = @import("zz.zig");
+        \\const b = @import("b.zig");
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\nconst b = @import(\"b.zig\");\nconst zz = @import(\"zz.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom attached comment travels with its import" {
+    const source =
+        \\pub fn main() !void {}
+        \\
+        \\// wasm support
+        \\const w = @import("w.zig");
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\n// wasm support\nconst w = @import(\"w.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom trailing comment stays with the body" {
+    const source =
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\// docs for main
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "// docs for main\npub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom comment adjacent to the first import travels" {
+    const source =
+        \\// attached note
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\n// attached note\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom blank-separated header stays at the top" {
+    const source =
+        \\// header
+        \\
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "// header\n\npub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom //! docs stay, adjacent note travels" {
+    const source =
+        \\//! Module docs.
+        \\// note
+        \\const b = @import("b.zig");
+        \\const a = @import("a.zig");
+        \\
+        \\pub fn main() !void {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expectEqualStrings(
+        "//! Module docs.\n\npub fn main() !void {}\n\n// note\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom preserves CRLF line endings" {
+    const source = "const b = @import(\"b.zig\");\r\nconst a = @import(\"a.zig\");\r\n\r\npub fn main() !void {}\r\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -642,7 +825,7 @@ test "buildSortedImportText: comment travels with its import" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const std_pos = std.mem.indexOf(u8, result, "const std") orelse return error.TestUnexpectedResult;
     const bar_pos = std.mem.indexOf(u8, result, "const bar") orelse return error.TestUnexpectedResult;
@@ -665,7 +848,7 @@ test "buildSortedImportText: blank-line-separated comment travels with its impor
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const std_pos = std.mem.indexOf(u8, result, "const std") orelse return error.TestUnexpectedResult;
     const comment_pos = std.mem.indexOf(u8, result, "// std comment") orelse return error.TestUnexpectedResult;
@@ -684,7 +867,7 @@ test "buildSortedImportText: alias imports hoisted after imports" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const bar_pos = std.mem.indexOf(u8, result, "const bar") orelse return error.TestUnexpectedResult;
     const debug_pos = std.mem.indexOf(u8, result, "const Debug = std.debug;") orelse return error.TestUnexpectedResult;
@@ -704,7 +887,7 @@ test "buildSortedImportText: @This() sorts first in the alias band" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const expected = "const std = @import(\"std\");\n\nconst IP = @This();\nconst Io = std.Io;\n\n";
     try std.testing.expectEqualStrings(expected, result);
@@ -724,7 +907,7 @@ test "buildSortedImportText: full band order with members and aliases" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const expected =
         \\const std = @import("std");
@@ -754,7 +937,7 @@ test "buildSortedImportText: README example sorts as documented" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const expected =
         \\const std = @import("std");
@@ -785,7 +968,7 @@ test "buildSortedImportText: aliases sorted by resolved path" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const expected =
         \\const std = @import("std");
@@ -810,7 +993,7 @@ test "processSource: hoisted stray import lands in its group" {
         \\
         \\const late = @import("late.zig");
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -830,7 +1013,7 @@ test "processSource: alias stranded below block is hoisted into the alias band" 
         \\
         \\pub fn main() {}
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -850,7 +1033,7 @@ test "processSource: blank above hoisted stray import is preserved" {
         \\
         \\pub fn main() {}
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -882,10 +1065,10 @@ test "processSource: output independent of input order" {
         \\
         \\pub fn main() {}
     ;
-    const r1 = try zsort.processSource(std.testing.allocator, forward, &.{});
+    const r1 = try zsort.processSource(std.testing.allocator, forward, &.{}, false);
     defer std.testing.allocator.free(r1.new_text);
     defer std.testing.allocator.free(r1.new_block);
-    const r2 = try zsort.processSource(std.testing.allocator, backward, &.{});
+    const r2 = try zsort.processSource(std.testing.allocator, backward, &.{}, false);
     defer std.testing.allocator.free(r2.new_text);
     defer std.testing.allocator.free(r2.new_block);
     try std.testing.expectEqualStrings(r1.new_text, r2.new_text);
@@ -899,7 +1082,7 @@ test "processSource: stray member import hoisted into member band" {
         \\
         \\const Thing = @import("thing.zig").Thing;
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -949,7 +1132,7 @@ test "processSource: typed import hoisted and sorted" {
         \\
         \\pub fn main() {}
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -968,7 +1151,7 @@ test "processSource: trailing comment on multiline import travels" {
         \\    "late.zig"
         \\); // late comment
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -986,7 +1169,7 @@ test "processSource: cimport block kept intact" {
         \\}); // c trailing
         \\const rest = 1;
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -1009,7 +1192,7 @@ test "processSource: stray cimport hoisted" {
         \\    #include <x.h>
         \\});
     ;
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
@@ -1020,7 +1203,7 @@ test "processSource: stray cimport hoisted" {
 
 test "processSource: comment-only file unchanged" {
     const source = "// just comments\n// more\n";
-    const result = try zsort.processSource(std.testing.allocator, source, &.{});
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
     defer if (result.changed) {
         std.testing.allocator.free(result.new_text);
         std.testing.allocator.free(result.new_block);
@@ -1042,7 +1225,7 @@ test "buildSortedImportText: comment above alias travels" {
     defer imports.deinit(std.testing.allocator);
     var aliases = try collectAliasesForTest(source);
     defer aliases.deinit(std.testing.allocator);
-    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end);
+    const result = try zsort.buildSortedImportText(std.testing.allocator, source, imports.items, aliases.items, block_end, false);
     defer std.testing.allocator.free(result);
     const comment_pos = std.mem.indexOf(u8, result, "// Debug alias") orelse return error.TestUnexpectedResult;
     const debug_pos = std.mem.indexOf(u8, result, "const Debug") orelse return error.TestUnexpectedResult;
@@ -1131,6 +1314,24 @@ test "parseArgs: multiple targets" {
     try std.testing.expectEqualStrings("tools", parsed.targets.items[1]);
     try std.testing.expectEqualStrings("src/main.zig", parsed.targets.items[2]);
     try std.testing.expectEqual(@as(usize, 0), parsed.banned_prefixes.items.len);
+}
+
+test "parseArgs: --bottom flag accepted in both modes" {
+    var msg: ?[]const u8 = null;
+    defer if (msg) |m| std.testing.allocator.free(m);
+
+    var check = try zsort.parseArgs(std.testing.allocator, &.{ "zsort", "--bottom", "check", "src" }, &msg);
+    defer check.deinit(std.testing.allocator);
+    try std.testing.expect(check.mode == .check);
+    try std.testing.expect(check.bottom);
+
+    var fix = try zsort.parseArgs(std.testing.allocator, &.{ "zsort", "fix", "src", "--bottom", "--ban-prefix", "./" }, &msg);
+    defer fix.deinit(std.testing.allocator);
+    try std.testing.expect(fix.mode == .fix);
+    try std.testing.expect(fix.bottom);
+    try std.testing.expectEqual(@as(usize, 1), fix.banned_prefixes.items.len);
+
+    try std.testing.expectError(error.UnexpectedArg, zsort.parseArgs(std.testing.allocator, &.{ "zsort", "check", "src", "--bottomx" }, &msg));
 }
 
 test "formatSummary: check mode, plain without color" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--bottom` option that moves the complete sorted import block to the end of a file.
  * Supported the option in both `check` and `fix` modes.
  * Preserved documentation, comments, spacing, and source newline style during relocation.
  * Added help text and command-line validation for the new option.

* **Documentation**
  * Documented `--bottom` usage and behavior in the README and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->