### PR TITLE
Normalize blank lines in bottom mode

### DIFF
--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -75,7 +75,6 @@ fn printStderr(io: compat.Io, comptime fmt: []const u8, args: anytype) void {
 /// `ansi_*` codes are the only intentional raw escape sequences.
 /// Returns `s` unchanged when clean (no allocation). Propagates
 /// `error.OutOfMemory` rather than ever returning the raw input.
-/// ponytail: the five bytes a terminal interprets; tab/DEL are cosmetic only
 pub fn escapeTerm(allocator: std.mem.Allocator, s: []const u8) ![]const u8 {
     var n: usize = 0;
     for (s) |b| {
@@ -314,7 +313,6 @@ fn splitLines(allocator: std.mem.Allocator, text: []const u8) !std.ArrayListUnma
 /// Minimal unified-style diff: trims common prefix/suffix lines and shows the
 /// changed middle with up to two context lines around it. When `use_color` is
 /// set, headers, hunks, and changed lines are ANSI-colored git-style.
-/// ponytail: prefix/suffix diff, switch to Myers if multi-hunk noise ever matters
 pub fn formatUnifiedDiff(
     allocator: std.mem.Allocator,
     file_path: []const u8,
@@ -443,7 +441,6 @@ fn matchesAnyIgnore(path: []const u8, ignores: []const []const u8) bool {
 /// Read `<dir>/.gitignore` and return its cleaned patterns, allocated with
 /// `allocator` (patterns and the slice belong to that allocator).
 /// Missing or unreadable files yield an empty list (not an error).
-/// ponytail: no wildcards or negation; entries match as path-component prefixes
 pub fn loadGitignore(io: compat.Io, allocator: std.mem.Allocator, dir: compat.Dir) ![]const []const u8 {
     const contents = compat.readFileAlloc(io, dir, ".gitignore", allocator, 1024 * 1024) catch return &[_][]const u8{};
     defer allocator.free(contents);
@@ -621,12 +618,10 @@ const ProcessResult = struct {
     changed: bool,
     banned: bool,
     banned_msg: ?[]const u8,
-    stray_count: usize,
-    /// A blank line was inserted between the sorted block and the body.
-    junction_blank: bool = false,
-    /// The collapsed output differs from the pre-collapse text, so the
-    /// change extends beyond the block region and needs a full-text diff.
-    normalized: bool = false,
+    /// The change is not confined to the block region, so check mode must
+    /// diff the full text (block moved, strays hoisted, seam blank inserted,
+    /// or body blanks normalized).
+    full_diff: bool = false,
 };
 
 pub fn processSource(
@@ -643,7 +638,6 @@ pub fn processSource(
             .changed = false,
             .banned = false,
             .banned_msg = null,
-            .stray_count = 0,
         };
     }
 
@@ -665,7 +659,6 @@ pub fn processSource(
             .changed = false,
             .banned = banned_msg != null,
             .banned_msg = banned_msg,
-            .stray_count = 0,
         };
     }
 
@@ -763,9 +756,7 @@ pub fn processSource(
         try full_buf.appendSlice(allocator, source[0..top_cut]);
         if (top_cut > 0 and rest.len > 0) try full_buf.appendSlice(allocator, nl);
         try full_buf.appendSlice(allocator, rest);
-        var junction = false;
         if (full_buf.items.len > 0 and !endsWithBlankLine(full_buf.items)) {
-            junction = true;
             // One newline terminates the body's last line, a second one
             // turns it into the separating blank line.
             try full_buf.appendSlice(allocator, nl);
@@ -781,8 +772,7 @@ pub fn processSource(
             .changed = !std.mem.eql(u8, source, owned),
             .banned = banned_msg != null,
             .banned_msg = banned_msg,
-            .stray_count = stray_imports.items.len,
-            .junction_blank = junction,
+            .full_diff = true,
         };
     }
 
@@ -824,9 +814,7 @@ pub fn processSource(
         .changed = changed,
         .banned = banned_msg != null,
         .banned_msg = banned_msg,
-        .stray_count = stray_imports.items.len,
-        .junction_blank = junction_blank,
-        .normalized = normalized,
+        .full_diff = stray_imports.items.len > 0 or junction_blank or normalized,
     };
 }
 
@@ -1220,9 +1208,9 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
                 printStdout(io, "  {s}Fixed:{s} {s}{s}{s}\n", .{ out_green, out_reset, out_yellow, esc_path, out_reset });
             }
         } else {
-            // The block moved to the end of the file; a block-only diff
-            // would show the whole file as moved, so diff the full text.
-            if (parsed.bottom or result.stray_count > 0 or result.junction_blank or result.normalized) {
+            // A block-only diff is only valid when the change is confined to
+            // the block region; otherwise diff the full text.
+            if (result.full_diff) {
                 showDiff(io, allocator, file_path, slot.source, result.new_text, color);
             } else {
                 showDiff(io, allocator, file_path, slot.source[0..result.block_end], result.new_block, color);

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -794,7 +794,7 @@ pub fn processSource(
         if (line.len != 0) break;
         scan_pos = le;
     }
-    const junction_blank = !has_trailing_comment and !endsWithBlankLine(new_imports) and rest.len > 0 and rest[0] != '\n' and rest[0] != '\r';
+    const junction_blank = !has_trailing_comment and !endsWithBlankLine(new_imports) and rest.len > 0;
 
     const full_new = if (junction_blank)
         try std.mem.concat(allocator, u8, &.{ new_imports, nl, rest })

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -624,6 +624,9 @@ const ProcessResult = struct {
     stray_count: usize,
     /// A blank line was inserted between the sorted block and the body.
     junction_blank: bool = false,
+    /// The collapsed output differs from the pre-collapse text, so the
+    /// change extends beyond the block region and needs a full-text diff.
+    normalized: bool = false,
 };
 
 pub fn processSource(
@@ -783,7 +786,6 @@ pub fn processSource(
         };
     }
 
-    const original_block = source[0..block_end];
     // The sorted block is separated from the body by a blank line unless the
     // block already ends with a blank line or a trailing comment (which stays
     // attached to the decl it documents).
@@ -803,7 +805,6 @@ pub fn processSource(
         scan_pos = le;
     }
     const junction_blank = !has_trailing_comment and !endsWithBlankLine(new_imports) and rest.len > 0 and rest[0] != '\n' and rest[0] != '\r';
-    const changed = !std.mem.eql(u8, original_block, new_imports) or stray_imports.items.len > 0 or junction_blank;
 
     const full_new = if (junction_blank)
         try std.mem.concat(allocator, u8, &.{ new_imports, nl, rest })
@@ -812,7 +813,9 @@ pub fn processSource(
     if (rest_owned) |owned| allocator.free(owned);
     errdefer allocator.free(full_new);
     const collapsed = try collapseBlankLines(allocator, full_new, true);
+    const normalized = !std.mem.eql(u8, full_new, collapsed);
     allocator.free(full_new);
+    const changed = !std.mem.eql(u8, source, collapsed);
 
     return .{
         .new_text = collapsed,
@@ -823,6 +826,7 @@ pub fn processSource(
         .banned_msg = banned_msg,
         .stray_count = stray_imports.items.len,
         .junction_blank = junction_blank,
+        .normalized = normalized,
     };
 }
 
@@ -1218,7 +1222,7 @@ fn runMain(allocator: std.mem.Allocator, args: []const []const u8, io: compat.Io
         } else {
             // The block moved to the end of the file; a block-only diff
             // would show the whole file as moved, so diff the full text.
-            if (parsed.bottom or result.stray_count > 0 or result.junction_blank) {
+            if (parsed.bottom or result.stray_count > 0 or result.junction_blank or result.normalized) {
                 showDiff(io, allocator, file_path, slot.source, result.new_text, color);
             } else {
                 showDiff(io, allocator, file_path, slot.source[0..result.block_end], result.new_block, color);

--- a/src/zsort.zig
+++ b/src/zsort.zig
@@ -269,20 +269,32 @@ pub fn buildSortedImportText(
         try buf.appendSlice(allocator, nl);
     }
 
-    var deduped: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer deduped.deinit(allocator);
-    var blank_run: usize = 0;
-    var line_pos: usize = 0;
-    while (line_pos < buf.items.len) {
-        const le = findLineEnd(buf.items, line_pos);
-        const line = buf.items[line_pos..le];
-        const is_blank = std.mem.trim(u8, line, " \t\r\n").len == 0;
-        blank_run = if (is_blank) blank_run + 1 else 0;
-        if (blank_run < 2) try deduped.appendSlice(allocator, line);
-        line_pos = le;
-    }
+    return collapseBlankLines(allocator, buf.items, false);
+}
 
-    return deduped.toOwnedSlice(allocator);
+/// Max one blank line between content lines; when `strip_trailing` is set,
+/// trailing blank lines are removed. Keeps the first line of each blank run
+/// verbatim so CRLF runs survive; blank detection ignores spaces, tabs, and
+/// `\r`.
+fn collapseBlankLines(allocator: std.mem.Allocator, text: []const u8, strip_trailing: bool) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var last_blank_start: ?usize = null;
+    var pos: usize = 0;
+    while (pos < text.len) {
+        const le = findLineEnd(text, pos);
+        const line = text[pos..le];
+        const is_blank = std.mem.trim(u8, line, " \t\r\n").len == 0;
+        if (!is_blank or last_blank_start == null) {
+            try out.appendSlice(allocator, line);
+            last_blank_start = if (is_blank) out.items.len - (le - pos) else null;
+        }
+        pos = le;
+    }
+    if (strip_trailing) {
+        if (last_blank_start) |start| out.shrinkRetainingCapacity(start);
+    }
+    return out.toOwnedSlice(allocator);
 }
 
 fn splitLines(allocator: std.mem.Allocator, text: []const u8) !std.ArrayListUnmanaged([]const u8) {
@@ -757,7 +769,7 @@ pub fn processSource(
             if (!endsWithBlankLine(full_buf.items)) try full_buf.appendSlice(allocator, nl);
         }
         try full_buf.appendSlice(allocator, new_imports);
-        const owned = try full_buf.toOwnedSlice(allocator);
+        const owned = try collapseBlankLines(allocator, full_buf.items, true);
         if (rest_owned) |owned_rest| allocator.free(owned_rest);
         return .{
             .new_text = owned,
@@ -798,9 +810,12 @@ pub fn processSource(
     else
         try std.mem.concat(allocator, u8, &.{ new_imports, rest });
     if (rest_owned) |owned| allocator.free(owned);
+    errdefer allocator.free(full_new);
+    const collapsed = try collapseBlankLines(allocator, full_new, true);
+    allocator.free(full_new);
 
     return .{
-        .new_text = full_new,
+        .new_text = collapsed,
         .new_block = new_imports,
         .block_end = block_end,
         .changed = changed,

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -225,6 +225,26 @@ test "processSource: no double blank when rest starts blank" {
     try std.testing.expect(!result.changed);
 }
 
+test "processSource: excessive blanks between block and body are normalized and reported" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\pub fn main() {}
+        \\
+        \\
+        \\const x = 1;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expect(result.normalized);
+    try std.testing.expectEqualStrings(
+        "const std = @import(\"std\");\n\npub fn main() {}\n\nconst x = 1;",
+        result.new_text,
+    );
+}
+
 test "processSource: doc comment stays attached to the following decl" {
     const source =
         \\const std = @import("std");

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -223,6 +223,7 @@ test "processSource: no double blank when rest starts blank" {
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(!result.changed);
+    try std.testing.expect(!result.full_diff);
 }
 
 test "processSource: excessive blanks between block and body are normalized and reported" {
@@ -238,7 +239,7 @@ test "processSource: excessive blanks between block and body are normalized and 
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
-    try std.testing.expect(result.normalized);
+    try std.testing.expect(result.full_diff);
     try std.testing.expectEqualStrings(
         "const std = @import(\"std\");\n\npub fn main() {}\n\nconst x = 1;",
         result.new_text,
@@ -432,6 +433,7 @@ test "processSource: --bottom moves the import block to the end of the file" {
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
+    try std.testing.expect(result.full_diff);
     try std.testing.expectEqualStrings(
         "pub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
         result.new_text,

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -246,6 +246,30 @@ test "processSource: excessive blanks between block and body are normalized and 
     );
 }
 
+test "processSource: junction blank inserted before a CR-prefixed body line" {
+    const source = "const std = @import(\"std\");\n\r pub fn main() {}\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "const std = @import(\"std\");\n\n\r pub fn main() {}\n",
+        result.new_text,
+    );
+}
+
+test "processSource: whitespace-only separator line is treated as a blank" {
+    const source = "const std = @import(\"std\");\n   \npub fn main() {}\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "const std = @import(\"std\");\n\npub fn main() {}\n",
+        result.new_text,
+    );
+}
+
 test "processSource: doc comment stays attached to the following decl" {
     const source =
         \\const std = @import("std");

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -199,7 +199,7 @@ test "processSource: blank line inserted between block and body" {
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
-    const expected = "const build_options = @import(\"build_options\");\n\npub fn main() void {}\n\n";
+    const expected = "const build_options = @import(\"build_options\");\n\npub fn main() void {}\n";
     try std.testing.expectEqualStrings(expected, result.new_text);
 }
 
@@ -579,6 +579,130 @@ test "processSource: --bottom preserves CRLF line endings" {
     try std.testing.expect(result.changed);
     try std.testing.expectEqualStrings(
         "pub fn main() !void {}\r\n\r\n" ++
+            "const a = @import(\"a.zig\");\r\n" ++
+            "const b = @import(\"b.zig\");\r\n",
+        result.new_text,
+    );
+    var prev: u8 = 0;
+    for (result.new_text) |ch| {
+        if (ch == '\n') try std.testing.expectEqual(@as(u8, '\r'), prev);
+        prev = ch;
+    }
+}
+
+test "processSource: --bottom collapses blank runs left in the body by hoisted bands" {
+    const source =
+        \\// Server timestamp.
+        \\var start_fuzzing_timestamp: i64 = undefined;
+        \\
+        \\pub fn main() !void {}
+        \\
+        \\const std = @import("std");
+        \\const Walk = @import("Walk");
+        \\
+        \\const gpa = std.heap.wasm_allocator;
+        \\const log = std.log;
+        \\const String = Slice(u8);
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "// Server timestamp.\n\n" ++
+            "var start_fuzzing_timestamp: i64 = undefined;\n\n" ++
+            "pub fn main() !void {}\n\n" ++
+            "const String = Slice(u8);\n\n" ++
+            "const std = @import(\"std\");\n\n" ++
+            "const Walk = @import(\"Walk\");\n\n" ++
+            "const gpa = std.heap.wasm_allocator;\n" ++
+            "const log = std.log;\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom is idempotent on an already-bottom banded file" {
+    const source =
+        \\pub fn main() !void {}
+        \\
+        \\const std = @import("std");
+        \\const Walk = @import("Walk");
+        \\
+        \\const gpa = std.heap.wasm_allocator;
+        \\const log = std.log;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\n" ++
+            "const std = @import(\"std\");\n\n" ++
+            "const Walk = @import(\"Walk\");\n\n" ++
+            "const gpa = std.heap.wasm_allocator;\n" ++
+            "const log = std.log;\n",
+        result.new_text,
+    );
+    const second_src = try std.testing.allocator.dupeZ(u8, result.new_text);
+    defer std.testing.allocator.free(second_src);
+    const second = try zsort.processSource(std.testing.allocator, second_src, &.{}, true);
+    defer std.testing.allocator.free(second.new_text);
+    defer std.testing.allocator.free(second.new_block);
+    try std.testing.expect(!second.changed);
+    try std.testing.expectEqualStrings(result.new_text, second.new_text);
+}
+
+test "processSource: hoisting stray bands leaves no blank runs at EOF" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\pub fn main() !void {}
+        \\
+        \\const a = @import("a.zig");
+        \\
+        \\const b = @import("b.zig");
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "const std = @import(\"std\");\n\n" ++
+            "const a = @import(\"a.zig\");\n" ++
+            "const b = @import(\"b.zig\");\n\n" ++
+            "pub fn main() !void {}\n",
+        result.new_text,
+    );
+}
+
+test "processSource: --bottom normalizes a trailing blank line once, then idempotent" {
+    const source = "pub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\n\nconst a = @import(\"a.zig\");\nconst b = @import(\"b.zig\");\n",
+        result.new_text,
+    );
+    const second_src = try std.testing.allocator.dupeZ(u8, result.new_text);
+    defer std.testing.allocator.free(second_src);
+    const second = try zsort.processSource(std.testing.allocator, second_src, &.{}, true);
+    defer std.testing.allocator.free(second.new_text);
+    defer std.testing.allocator.free(second.new_block);
+    try std.testing.expect(!second.changed);
+    try std.testing.expectEqualStrings(result.new_text, second.new_text);
+}
+
+test "processSource: --bottom collapses blank runs with CRLF line endings" {
+    const source = "const std = @import(\"std\");\r\n\r\npub fn main() !void {}\r\n\r\nconst a = @import(\"a.zig\");\r\n\r\nconst b = @import(\"b.zig\");\r\n";
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(
+        "pub fn main() !void {}\r\n\r\n" ++
+            "const std = @import(\"std\");\r\n\r\n" ++
             "const a = @import(\"a.zig\");\r\n" ++
             "const b = @import(\"b.zig\");\r\n",
         result.new_text,
@@ -1043,7 +1167,7 @@ test "processSource: blank above hoisted stray import is preserved" {
     defer std.testing.allocator.free(result.new_text);
     defer std.testing.allocator.free(result.new_block);
     try std.testing.expect(result.changed);
-    try std.testing.expect(std.mem.indexOf(u8, result.new_text, "const log = std.log.scoped(.x);\n\n\npub fn main") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.new_text, "const log = std.log.scoped(.x);\n\npub fn main") != null);
 }
 
 test "processSource: output independent of input order" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized consecutive blank lines to a single blank line.
  * Ensured processed files end with one trailing newline.
  * Preserved CRLF line endings during formatting.
  * Improved spacing around hoisted imports and trailing content.
  * Improved full-file change reporting when formatting modifies output.
  * Made bottom-section formatting consistent and idempotent.

* **Tests**
  * Added coverage for normalization, import grouping, EOF cleanup, idempotence, whitespace separators, and CRLF handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->