### PR TITLE
Fix import alias resolution

### DIFF
--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -28,6 +28,10 @@ pub const Import = struct {
     /// Full decl text (`source[start..end]`); final sort tiebreak so the
     /// output never depends on input order.
     text: []const u8 = "",
+    /// False when an alias's base name is not a top-level import (e.g. a
+    /// local decl like `system`); such decls are not block members and
+    /// stay in place.
+    resolved: bool = true,
 
     fn lessThan(ctx: void, a: Import, b: Import) bool {
         _ = ctx;
@@ -148,19 +152,34 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
 
     // Aliases reference imports by their const name; resolve that name to
     // the imported path so the alias band sorts by module, not by local
-    // alias. Unresolvable bases (local structs, unimported names) keep the
-    // chain text. Duplicate const names (broken file): first match wins.
+    // alias. An alias whose base name is not an import (a local decl like
+    // `system`, a struct in the same file) is not an import alias at all:
+    // drop it so it stays in the body. Duplicate const names (broken
+    // file): first match wins.
     for (result.aliases.items) |*alias| {
         const dot = std.mem.indexOfScalar(u8, alias.path, '.') orelse continue;
         const base = alias.path[0..dot];
+        var matched = false;
         for (result.imports.items) |imp| {
             if (std.mem.eql(u8, imp.name, base)) {
                 alias.path = imp.path;
                 alias.class = classify(imp.path);
+                matched = true;
                 break;
             }
         }
+        if (!matched) alias.resolved = false;
     }
+    var alias_i: usize = 0;
+    while (alias_i < result.aliases.items.len) {
+        if (!result.aliases.items[alias_i].resolved) {
+            _ = result.aliases.swapRemove(alias_i);
+        } else alias_i += 1;
+    }
+
+    // The block ends at the first line not covered by a collected span;
+    // dropping unresolvable aliases may shorten the region.
+    result.block_end = lineBlockEnd(source, result.imports.items, result.aliases.items);
 
     // Aliases below the block are marked stray so they can be hoisted into
     // the alias band, mirroring how stray imports are hoisted.
@@ -199,6 +218,9 @@ fn collectAllowedOffsets(allocator: std.mem.Allocator, tree: Ast) !std.ArrayList
 /// base of a dotted chain like `@import("a").Foo.Bar`.
 fn importHeadOffset(tree: Ast, init: Ast.Node.Index) ?usize {
     var cur = init;
+    while (tree.nodeTag(cur) == .address_of) {
+        cur = tree.nodeData(cur).node;
+    }
     while (tree.nodeTag(cur) == .field_access) {
         cur = tree.nodeData(cur).node_and_token[0];
     }
@@ -286,8 +308,13 @@ fn classifyDecl(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]c
     const comment_start = findCommentStart(source, findLineStart(source, start));
 
     // Base of a dotted chain: `@import("a").Foo` → the `@import` call.
+    // `&` wraps member chains (`&@import("root").step_list`) to reference
+    // a decl of the imported module; peel it so the chain is recognized.
     var base = init;
     var member = false;
+    while (tree.nodeTag(base) == .address_of) {
+        base = tree.nodeData(base).node;
+    }
     while (tree.nodeTag(base) == .field_access) {
         base = tree.nodeData(base).node_and_token[0];
         member = true;

--- a/src/ast_scan_test.zig
+++ b/src/ast_scan_test.zig
@@ -32,16 +32,13 @@ test "findImportBlockEnd: ends at first non-import" {
     try std.testing.expectEqual("const std = @import(\"std\");\n\n".len, blockEndForTest(source));
 }
 
-test "findImportBlockEnd: alias to struct-like module does not end block" {
+test "findImportBlockEnd: alias to unimported module ends the block" {
     const source =
         \\const std = @import("std");
         \\const Enum = enums.Kind;
         \\const Other = @import("other");
     ;
-    try std.testing.expectEqual(
-        "const std = @import(\"std\");\nconst Enum = enums.Kind;\nconst Other = @import(\"other\");".len,
-        blockEndForTest(source),
-    );
+    try std.testing.expectEqual("const std = @import(\"std\");\n".len, blockEndForTest(source));
 }
 
 test "collectImports: braces in multiline-string line don't affect depth" {
@@ -130,12 +127,43 @@ test "analyze: alias to member import resolves" {
     try std.testing.expectEqualStrings("message_handler.zig", analysis.aliases.items[0].path);
 }
 
-test "analyze: unresolvable alias keeps chain text" {
+test "analyze: unresolvable alias is not collected" {
     const source = "const Len = Internal.len;\n";
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.aliases.items.len);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
+}
+
+test "analyze: alias with unresolvable base is not collected" {
+    const source =
+        \\const std = @import("std");
+        \\const AF = system.AF;
+        \\const Debug = std.debug;
+    ;
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("Internal.len", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std", analysis.aliases.items[0].path);
+    try std.testing.expectEqual("const std = @import(\"std\");\n".len, analysis.block_end);
+}
+
+test "analyze: address-of import chain collected as member import" {
+    const source = "const step_list = &@import(\"root\").step_list;\n";
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), analysis.imports.items.len);
+    try std.testing.expect(analysis.imports.items[0].member);
+    try std.testing.expectEqualStrings("root", analysis.imports.items[0].path);
+    try std.testing.expectEqual(ast_scan.class_local, analysis.imports.items[0].class);
+}
+
+test "analyze: address-of of a local identifier is not an alias" {
+    const source = "const p = &foo;\n";
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.aliases.items.len);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
 }
 
 test "analyze: call-result chain is not an alias" {

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -1034,6 +1034,7 @@ test "buildSortedImportText: blank-line-separated comment travels with its impor
 test "buildSortedImportText: alias imports hoisted after imports" {
     const source =
         \\const bar = @import("bar");
+        \\const std = @import("std");
         \\const Debug = std.debug;
         \\
         \\const rest = 1;
@@ -1268,6 +1269,154 @@ test "processSource: stray member import hoisted into member band" {
     try std.testing.expect(std.mem.indexOf(u8, result.new_text, "pub fn main") != null);
 }
 
+test "processSource: re-export of a local module stays in place" {
+    const source =
+        \\const std = @import("std");
+        \\const Debug = std.debug;
+        \\const system = struct {
+        \\    pub const AF = 1;
+        \\};
+        \\
+        \\pub const AF = system.AF;
+        \\
+        \\const mem = std.mem;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.new_text, "pub const AF = system.AF;"));
+    const mem_pos = std.mem.indexOf(u8, result.new_text, "const mem = std.mem;") orelse return error.TestUnexpectedResult;
+    const system_pos = std.mem.indexOf(u8, result.new_text, "const system = struct") orelse return error.TestUnexpectedResult;
+    const af_pos = std.mem.indexOf(u8, result.new_text, "pub const AF = system.AF;") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(mem_pos < system_pos);
+    try std.testing.expect(system_pos < af_pos);
+}
+
+test "processSource: --bottom keeps re-export of a local module in place" {
+    const source =
+        \\const std = @import("std");
+        \\const Debug = std.debug;
+        \\const system = struct {
+        \\    pub const AF = 1;
+        \\};
+        \\
+        \\pub const AF = system.AF;
+        \\
+        \\const mem = std.mem;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.new_text, "pub const AF = system.AF;"));
+    const af_pos = std.mem.indexOf(u8, result.new_text, "pub const AF = system.AF;") orelse return error.TestUnexpectedResult;
+    const std_pos = std.mem.indexOf(u8, result.new_text, "const std = @import") orelse return error.TestUnexpectedResult;
+    const system_pos = std.mem.indexOf(u8, result.new_text, "const system = struct") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(system_pos < af_pos);
+    try std.testing.expect(af_pos < std_pos);
+}
+
+test "processSource: pub re-export with resolvable base still sorted" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\pub fn main() {}
+        \\
+        \\pub const Debug = std.debug;
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const debug_pos = std.mem.indexOf(u8, result.new_text, "pub const Debug") orelse return error.TestUnexpectedResult;
+    const main_pos = std.mem.indexOf(u8, result.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(debug_pos < main_pos);
+}
+
+test "processSource: pub import still sorted" {
+    const source =
+        \\const bar = @import("bar");
+        \\
+        \\pub fn main() {}
+        \\
+        \\pub const BitStack = @import("BitStack.zig");
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const bit_pos = std.mem.indexOf(u8, result.new_text, "pub const BitStack") orelse return error.TestUnexpectedResult;
+    const bar_pos = std.mem.indexOf(u8, result.new_text, "const bar") orelse return error.TestUnexpectedResult;
+    const main_pos = std.mem.indexOf(u8, result.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(bar_pos < bit_pos);
+    try std.testing.expect(bit_pos < main_pos);
+}
+
+test "processSource: address-of import chain sorted into member band" {
+    const source =
+        \\const step_list = &@import("root").step_list;
+        \\const fmtEscapeHtml = @import("root").fmtEscapeHtml;
+        \\const std = @import("std");
+        \\
+        \\pub fn main() {}
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, false);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    const std_pos = std.mem.indexOf(u8, result.new_text, "const std = @import") orelse return error.TestUnexpectedResult;
+    const fmt_pos = std.mem.indexOf(u8, result.new_text, "const fmtEscapeHtml") orelse return error.TestUnexpectedResult;
+    const step_pos = std.mem.indexOf(u8, result.new_text, "const step_list") orelse return error.TestUnexpectedResult;
+    const main_pos = std.mem.indexOf(u8, result.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std_pos < fmt_pos);
+    try std.testing.expect(fmt_pos < step_pos);
+    try std.testing.expect(step_pos < main_pos);
+    try std.testing.expect(std.mem.indexOf(u8, result.new_text, "const fmtEscapeHtml = @import(\"root\").fmtEscapeHtml;\nconst step_list = &@import(\"root\").step_list;") != null);
+}
+
+test "hasBannedPatterns: address-of import chain is allowed" {
+    const source = "const step_list = &@import(\"root\").step_list;\n";
+    try std.testing.expectEqual(@as(?[]const u8, null), try zsort.hasBannedPatterns(std.testing.allocator, source, &.{}));
+}
+
+test "processSource: posix-style re-export block untouched and idempotent" {
+    const source =
+        \\const std = @import("std");
+        \\
+        \\const system = struct {
+        \\    pub const AF = 1;
+        \\    pub const E = 2;
+        \\};
+        \\
+        \\pub const AF = system.AF;
+        \\pub const E = system.E;
+        \\
+        \\pub fn main() {}
+    ;
+    for ([_]bool{ false, true }) |bottom| {
+        const r1 = try zsort.processSource(std.testing.allocator, source, &.{}, bottom);
+        defer std.testing.allocator.free(r1.new_text);
+        defer std.testing.allocator.free(r1.new_block);
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, r1.new_text, "pub const AF = system.AF;"));
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, r1.new_text, "pub const E = system.E;"));
+        const system_pos = std.mem.indexOf(u8, r1.new_text, "const system = struct") orelse return error.TestUnexpectedResult;
+        const af_pos = std.mem.indexOf(u8, r1.new_text, "pub const AF = system.AF;") orelse return error.TestUnexpectedResult;
+        const e_pos = std.mem.indexOf(u8, r1.new_text, "pub const E = system.E;") orelse return error.TestUnexpectedResult;
+        const main_pos = std.mem.indexOf(u8, r1.new_text, "pub fn main") orelse return error.TestUnexpectedResult;
+        try std.testing.expect(system_pos < af_pos);
+        try std.testing.expect(af_pos < e_pos);
+        try std.testing.expect(e_pos < main_pos);
+
+        const r1_z = try std.testing.allocator.dupeZ(u8, r1.new_text);
+        defer std.testing.allocator.free(r1_z);
+        const r2 = try zsort.processSource(std.testing.allocator, r1_z, &.{}, bottom);
+        defer std.testing.allocator.free(r2.new_text);
+        defer std.testing.allocator.free(r2.new_block);
+        try std.testing.expect(!r2.changed);
+    }
+}
+
 test "hasBannedPatterns: nested re-export import not banned" {
     const source =
         \\const lib = struct {
@@ -1391,6 +1540,7 @@ test "processSource: comment-only file unchanged" {
 test "buildSortedImportText: comment above alias travels" {
     const source =
         \\const bar = @import("bar");
+        \\const std = @import("std");
         \\// Debug alias
         \\const Debug = std.debug;
         \\


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import detection for address-of expressions and member chains.
  * Unresolved aliases are now excluded from import blocks, while valid aliases remain supported.
  * Import block boundaries are recalculated correctly after alias resolution.
  * Local identifiers are no longer incorrectly treated as imports.

* **Sorting**
  * Improved handling of re-exports, public aliases, and address-of import chains.
  * Import sorting is now stable and consistent across standard and bottom-placement modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->