### PR TITLE
Fix Alias Chain

### DIFF
--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -15,6 +15,9 @@ pub const class_local: u2 = 2;
 pub const Import = struct {
     start: usize,
     end: usize,
+    /// Resolved import path; for aliases, the full resolved dotted chain
+    /// (`std.mem.Allocator`) used as the alias-band sort key: parents
+    /// before their members, alphabetical per level.
     path: []const u8,
     class: u2,
     stray: bool = false,
@@ -151,14 +154,14 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
     result.allowed = try collectAllowedOffsets(allocator, tree);
 
     // Aliases reference imports by their const name; resolve that name to
-    // the imported path so the alias band sorts by module, not by local
-    // alias. A base may itself be an alias (`const Allocator = mem.Allocator`
-    // over `const mem = std.mem`); container-scope consts are
-    // order-independent, so resolution iterates to a fixed point. An alias
-    // whose base is neither an import nor a resolved alias (a local decl
-    // like `system`, a struct in the same file) is not an import alias at
-    // all: drop it so it stays in the body. Duplicate const names (broken
-    // file): first match wins.
+    // the full dotted chain (`const Allocator = mem.Allocator` over
+    // `const mem = std.mem` → `std.mem.Allocator`) so the alias band sorts
+    // by chain: parents before their members, alphabetical per level.
+    // Container-scope consts are order-independent, so resolution iterates
+    // to a fixed point. An alias whose base is neither an import nor a
+    // resolved alias (a local decl like `system`, a struct in the same
+    // file) is not an import alias at all: drop it so it stays in the
+    // body. Duplicate const names (broken file): first match wins.
     for (result.aliases.items) |*alias| {
         if (std.mem.indexOfScalar(u8, alias.path, '.') != null) alias.resolved = false;
     }
@@ -169,9 +172,11 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
             if (alias.resolved) continue;
             const dot = std.mem.indexOfScalar(u8, alias.path, '.') orelse continue;
             const base = alias.path[0..dot];
+            const suffix = alias.path[dot..];
             for (result.imports.items) |imp| {
                 if (std.mem.eql(u8, imp.name, base)) {
-                    alias.path = imp.path;
+                    alias.path = try std.mem.concat(allocator, u8, &.{ imp.path, suffix });
+                    try result.owned_paths.append(allocator, alias.path);
                     alias.class = classify(imp.path);
                     alias.resolved = true;
                     changed = true;
@@ -181,7 +186,8 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
             if (alias.resolved) continue;
             for (result.aliases.items) |*other| {
                 if (other.resolved and std.mem.eql(u8, other.name, base)) {
-                    alias.path = other.path;
+                    alias.path = try std.mem.concat(allocator, u8, &.{ other.path, suffix });
+                    try result.owned_paths.append(allocator, alias.path);
                     alias.class = other.class;
                     alias.resolved = true;
                     changed = true;

--- a/src/ast_scan.zig
+++ b/src/ast_scan.zig
@@ -28,9 +28,9 @@ pub const Import = struct {
     /// Full decl text (`source[start..end]`); final sort tiebreak so the
     /// output never depends on input order.
     text: []const u8 = "",
-    /// False when an alias's base name is not a top-level import (e.g. a
-    /// local decl like `system`); such decls are not block members and
-    /// stay in place.
+    /// False when an alias's base name is neither a top-level import nor a
+    /// resolved alias (e.g. a local decl like `system`); such decls are not
+    /// block members and stay in place.
     resolved: bool = true,
 
     fn lessThan(ctx: void, a: Import, b: Import) bool {
@@ -152,23 +152,43 @@ pub fn analyze(allocator: std.mem.Allocator, source: [:0]const u8) !Analysis {
 
     // Aliases reference imports by their const name; resolve that name to
     // the imported path so the alias band sorts by module, not by local
-    // alias. An alias whose base name is not an import (a local decl like
-    // `system`, a struct in the same file) is not an import alias at all:
-    // drop it so it stays in the body. Duplicate const names (broken
+    // alias. A base may itself be an alias (`const Allocator = mem.Allocator`
+    // over `const mem = std.mem`); container-scope consts are
+    // order-independent, so resolution iterates to a fixed point. An alias
+    // whose base is neither an import nor a resolved alias (a local decl
+    // like `system`, a struct in the same file) is not an import alias at
+    // all: drop it so it stays in the body. Duplicate const names (broken
     // file): first match wins.
     for (result.aliases.items) |*alias| {
-        const dot = std.mem.indexOfScalar(u8, alias.path, '.') orelse continue;
-        const base = alias.path[0..dot];
-        var matched = false;
-        for (result.imports.items) |imp| {
-            if (std.mem.eql(u8, imp.name, base)) {
-                alias.path = imp.path;
-                alias.class = classify(imp.path);
-                matched = true;
-                break;
+        if (std.mem.indexOfScalar(u8, alias.path, '.') != null) alias.resolved = false;
+    }
+    var changed = true;
+    while (changed) {
+        changed = false;
+        for (result.aliases.items) |*alias| {
+            if (alias.resolved) continue;
+            const dot = std.mem.indexOfScalar(u8, alias.path, '.') orelse continue;
+            const base = alias.path[0..dot];
+            for (result.imports.items) |imp| {
+                if (std.mem.eql(u8, imp.name, base)) {
+                    alias.path = imp.path;
+                    alias.class = classify(imp.path);
+                    alias.resolved = true;
+                    changed = true;
+                    break;
+                }
+            }
+            if (alias.resolved) continue;
+            for (result.aliases.items) |*other| {
+                if (other.resolved and std.mem.eql(u8, other.name, base)) {
+                    alias.path = other.path;
+                    alias.class = other.class;
+                    alias.resolved = true;
+                    changed = true;
+                    break;
+                }
             }
         }
-        if (!matched) alias.resolved = false;
     }
     var alias_i: usize = 0;
     while (alias_i < result.aliases.items.len) {
@@ -368,6 +388,7 @@ fn classifyDecl(allocator: std.mem.Allocator, owned: *std.ArrayListUnmanaged([]c
             .class = classify(chain[0..dot]),
             .comment_start = comment_start,
             .name = name,
+            .member = member,
             .text = text,
         }, .alias = true };
     }

--- a/src/ast_scan_test.zig
+++ b/src/ast_scan_test.zig
@@ -92,7 +92,7 @@ test "analyze: chained member import path is base" {
     try std.testing.expectEqualStrings("a.zig", analysis.imports.items[0].path);
 }
 
-test "analyze: alias resolves to import path" {
+test "analyze: alias resolves to its full chain" {
     const source =
         \\const connection_state = @import("connection/state.zig");
         \\const Connection = connection_state.Connection;
@@ -100,11 +100,11 @@ test "analyze: alias resolves to import path" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("connection/state.zig", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("connection/state.zig.Connection", analysis.aliases.items[0].path);
     try std.testing.expectEqual(ast_scan.class_local, analysis.aliases.items[0].class);
 }
 
-test "analyze: alias to std resolves to std" {
+test "analyze: alias to std resolves to its chain" {
     const source =
         \\const std = @import("std");
         \\const Debug = std.debug;
@@ -112,7 +112,7 @@ test "analyze: alias to std resolves to std" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("std", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std.debug", analysis.aliases.items[0].path);
     try std.testing.expectEqual(ast_scan.class_std_builtin, analysis.aliases.items[0].class);
 }
 
@@ -124,7 +124,7 @@ test "analyze: alias to member import resolves" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("message_handler.zig", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("message_handler.zig.Config", analysis.aliases.items[0].path);
 }
 
 test "analyze: alias to an alias base resolves" {
@@ -136,8 +136,9 @@ test "analyze: alias to an alias base resolves" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 2), analysis.aliases.items.len);
+    try std.testing.expectEqualStrings("std.mem", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std.mem.Allocator", analysis.aliases.items[1].path);
     for (analysis.aliases.items) |alias| {
-        try std.testing.expectEqualStrings("std", alias.path);
         try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
         try std.testing.expect(alias.member);
     }
@@ -154,8 +155,10 @@ test "analyze: multi-hop alias chain resolves" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 3), analysis.aliases.items.len);
+    try std.testing.expectEqualStrings("std.mem", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std.mem.fmt", analysis.aliases.items[1].path);
+    try std.testing.expectEqualStrings("std.mem.fmt.Writer", analysis.aliases.items[2].path);
     for (analysis.aliases.items) |alias| {
-        try std.testing.expectEqualStrings("std", alias.path);
         try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
     }
     try std.testing.expectEqual(source.len, analysis.block_end);
@@ -170,8 +173,9 @@ test "analyze: alias chain resolves regardless of decl order" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 2), analysis.aliases.items.len);
+    try std.testing.expectEqualStrings("std.mem", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std.mem.Allocator", analysis.aliases.items[1].path);
     for (analysis.aliases.items) |alias| {
-        try std.testing.expectEqualStrings("std", alias.path);
         try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
     }
     try std.testing.expectEqual(source.len, analysis.block_end);
@@ -205,7 +209,7 @@ test "analyze: alias with unresolvable base is not collected" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("std", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("std.debug", analysis.aliases.items[0].path);
     try std.testing.expectEqual("const std = @import(\"std\");\n".len, analysis.block_end);
 }
 
@@ -248,7 +252,7 @@ test "analyze: alias resolves with tab-separated decl name" {
     var analysis = try ast_scan.analyze(std.testing.allocator, source);
     defer analysis.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), analysis.aliases.items.len);
-    try std.testing.expectEqualStrings("a", analysis.aliases.items[0].path);
+    try std.testing.expectEqualStrings("a.Y", analysis.aliases.items[0].path);
 }
 
 test "analyze: escaped import path is decoded" {

--- a/src/ast_scan_test.zig
+++ b/src/ast_scan_test.zig
@@ -127,6 +127,67 @@ test "analyze: alias to member import resolves" {
     try std.testing.expectEqualStrings("message_handler.zig", analysis.aliases.items[0].path);
 }
 
+test "analyze: alias to an alias base resolves" {
+    const source =
+        \\const std = @import("std");
+        \\const mem = std.mem;
+        \\const Allocator = mem.Allocator;
+    ;
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), analysis.aliases.items.len);
+    for (analysis.aliases.items) |alias| {
+        try std.testing.expectEqualStrings("std", alias.path);
+        try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
+        try std.testing.expect(alias.member);
+    }
+    try std.testing.expectEqual(source.len, analysis.block_end);
+}
+
+test "analyze: multi-hop alias chain resolves" {
+    const source =
+        \\const std = @import("std");
+        \\const mem = std.mem;
+        \\const fmt = mem.fmt;
+        \\const Writer = fmt.Writer;
+    ;
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), analysis.aliases.items.len);
+    for (analysis.aliases.items) |alias| {
+        try std.testing.expectEqualStrings("std", alias.path);
+        try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
+    }
+    try std.testing.expectEqual(source.len, analysis.block_end);
+}
+
+test "analyze: alias chain resolves regardless of decl order" {
+    const source =
+        \\const Allocator = mem.Allocator;
+        \\const mem = std.mem;
+        \\const std = @import("std");
+    ;
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), analysis.aliases.items.len);
+    for (analysis.aliases.items) |alias| {
+        try std.testing.expectEqualStrings("std", alias.path);
+        try std.testing.expectEqual(ast_scan.class_std_builtin, alias.class);
+    }
+    try std.testing.expectEqual(source.len, analysis.block_end);
+}
+
+test "analyze: cyclic alias chain is not collected" {
+    const source =
+        \\const A = B.x;
+        \\const B = A.x;
+    ;
+    var analysis = try ast_scan.analyze(std.testing.allocator, source);
+    defer analysis.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), analysis.aliases.items.len);
+    try std.testing.expectEqual(@as(usize, 0), analysis.imports.items.len);
+}
+
 test "analyze: unresolvable alias is not collected" {
     const source = "const Len = Internal.len;\n";
     var analysis = try ast_scan.analyze(std.testing.allocator, source);

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -1201,6 +1201,47 @@ test "processSource: alias stranded below block is hoisted into the alias band" 
     try std.testing.expect(alloc_pos < log_pos);
 }
 
+test "processSource: alias to alias base lands in the alias band (bottom)" {
+    const source =
+        \\//! header
+        \\
+        \\const body = 1;
+        \\
+        \\const std = @import("std");
+        \\
+        \\const Io = std.Io;
+        \\const assert = std.debug.assert;
+        \\const log = std.log;
+        \\const mem = std.mem;
+        \\const Allocator = mem.Allocator;
+    ;
+    const expected =
+        \\//! header
+        \\
+        \\const body = 1;
+        \\
+        \\const std = @import("std");
+        \\
+        \\const Allocator = mem.Allocator;
+        \\const Io = std.Io;
+        \\const assert = std.debug.assert;
+        \\const log = std.log;
+        \\const mem = std.mem;
+        \\
+    ;
+    const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);
+    defer std.testing.allocator.free(result.new_text);
+    defer std.testing.allocator.free(result.new_block);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqualStrings(expected, result.new_text);
+    const result_src = try std.testing.allocator.dupeZ(u8, result.new_text);
+    defer std.testing.allocator.free(result_src);
+    const result2 = try zsort.processSource(std.testing.allocator, result_src, &.{}, true);
+    defer std.testing.allocator.free(result2.new_text);
+    defer std.testing.allocator.free(result2.new_block);
+    try std.testing.expect(!result2.changed);
+}
+
 test "processSource: blank above hoisted stray import is preserved" {
     const source =
         \\const std = @import("std");

--- a/src/zsort_test.zig
+++ b/src/zsort_test.zig
@@ -1222,11 +1222,11 @@ test "processSource: alias to alias base lands in the alias band (bottom)" {
         \\
         \\const std = @import("std");
         \\
-        \\const Allocator = mem.Allocator;
         \\const Io = std.Io;
         \\const assert = std.debug.assert;
         \\const log = std.log;
         \\const mem = std.mem;
+        \\const Allocator = mem.Allocator;
         \\
     ;
     const result = try zsort.processSource(std.testing.allocator, source, &.{}, true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import-alias resolution for multi-level and out-of-order aliases.
  * Preserved member classification for aliases.
  * Correctly rejects cyclic aliases and aliases based on local declarations.
  * Fixed deterministic ordering for aliased imports with bottom placement.

* **Tests**
  * Added coverage for chained, cyclic, and order-independent aliases.
  * Added regression coverage for stable, repeatable import sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->